### PR TITLE
wavm: set context when calling __GLOBAL__ functions.

### DIFF
--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -425,7 +425,9 @@ void Wavm::start(Context* context) {
     }
 
     if (emscriptenInstance_) {
-      Emscripten::initializeGlobals(emscriptenInstance_, context_, irModule_, moduleInstance_);
+      CALL_WITH_CONTEXT(
+          Emscripten::initializeGlobals(emscriptenInstance_, context_, irModule_, moduleInstance_),
+          context);
     }
 
     f = asFunctionNullable(getInstanceExport(moduleInstance_, "__post_instantiate"));


### PR DESCRIPTION
Signed-off-by: Piotr Sikora <piotrsikora@google.com>