### PR TITLE
wasm: provide working _emscripten_get_heap_size().

### DIFF
--- a/source/extensions/common/wasm/null/null.cc
+++ b/source/extensions/common/wasm/null/null.cc
@@ -59,6 +59,7 @@ struct NullVm : public WasmVm {
   bool load(const std::string& code, bool allow_precompiled) override;
   void link(absl::string_view debug_name, bool needs_emscripten) override;
   void start(Common::Wasm::Context* context) override;
+  uint64_t getMemorySize() override;
   absl::string_view getMemory(uint64_t pointer, uint64_t size) override;
   bool getMemoryOffset(void* host_pointer, uint64_t* vm_pointer) override;
   bool setMemory(uint64_t pointer, uint64_t size, void* data) override;
@@ -138,6 +139,8 @@ void NullVm::start(Common::Wasm::Context* context) {
   SaveRestoreContext saved_context(context);
   plugin_->start();
 }
+
+uint64_t NullVm::getMemorySize() { return std::numeric_limits<uint64_t>::max(); }
 
 absl::string_view NullVm::getMemory(uint64_t pointer, uint64_t size) {
   return {reinterpret_cast<char*>(pointer), static_cast<size_t>(size)};

--- a/source/extensions/common/wasm/v8/v8.cc
+++ b/source/extensions/common/wasm/v8/v8.cc
@@ -56,6 +56,8 @@ public:
   std::unique_ptr<WasmVm> clone() override { return nullptr; }
 
   void start(Context* context) override;
+
+  uint64_t getMemorySize() override;
   absl::string_view getMemory(uint64_t pointer, uint64_t size) override;
   bool getMemoryOffset(void* host_pointer, uint64_t* vm_pointer) override;
   bool setMemory(uint64_t pointer, uint64_t size, void* data) override;
@@ -494,6 +496,11 @@ void V8::callModuleFunction(Context* context, absl::string_view functionName,
         fmt::format("Function: {} failed: {}", functionName,
                     absl::string_view(trap->message().get(), trap->message().size())));
   }
+}
+
+uint64_t V8::getMemorySize() {
+  ENVOY_LOG(trace, "[wasm] getMemorySize()");
+  return memory_->data_size();
 }
 
 absl::string_view V8::getMemory(uint64_t pointer, uint64_t size) {

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -486,7 +486,10 @@ void grpcSendHandler(void* raw_context, Word token, Word message_ptr, Word messa
   context->grpcSend(token, message, end_stream);
 }
 
-Word _emscripten_get_heap_sizeHandler(void*) { return std::numeric_limits<int32_t>::max(); }
+Word _emscripten_get_heap_sizeHandler(void* raw_context) {
+  auto context = WASM_CONTEXT(raw_context);
+  return context->wasmVm()->getMemorySize();
+}
 
 Word _emscripten_memcpy_bigHandler(void*, Word, Word, Word) {
   throw WasmException("emscripten emscripten_memcpy_big");

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -706,6 +706,8 @@ public:
   // Call the 'start' function and initialize globals.
   virtual void start(Context*) PURE;
 
+  // Get size of the currently allocated memory in the VM.
+  virtual uint64_t getMemorySize() PURE;
   // Convert a block of memory in the VM to a string_view.
   virtual absl::string_view getMemory(uint64_t pointer, uint64_t size) PURE;
   // Convert a host pointer to memory in the VM into a VM "pointer" (an offset into the Memory).

--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -238,6 +238,7 @@ struct Wavm : public WasmVm {
   bool load(const std::string& code, bool allow_precompiled) override;
   void link(absl::string_view debug_name, bool needs_emscripten) override;
   void start(Context* context) override;
+  uint64_t getMemorySize() override;
   absl::string_view getMemory(uint64_t pointer, uint64_t size) override;
   bool getMemoryOffset(void* host_pointer, uint64_t* vm_pointer) override;
   bool setMemory(uint64_t pointer, uint64_t size, void* data) override;
@@ -314,7 +315,6 @@ struct Wavm : public WasmVm {
   std::unordered_map<std::pair<std::string, std::string>, WavmGlobalBase*, PairHash>
       intrinsicGlobals_;
   uint8_t* memory_base_ = nullptr;
-  size_t memory_size_ = 0;
 };
 
 Wavm::~Wavm() {
@@ -339,8 +339,6 @@ std::unique_ptr<WasmVm> Wavm::clone() {
   wavm->compartment_ = WAVM::Runtime::cloneCompartment(compartment_);
   wavm->memory_ = WAVM::Runtime::remapToClonedCompartment(memory_, wavm->compartment_);
   memory_base_ = WAVM::Runtime::getMemoryBaseAddress(memory_);
-  memory_size_ = WAVM::Runtime::getMemoryMaxPages(memory_);
-  memory_size_ *= wasmPageSize;
   wavm->context_ = WAVM::Runtime::createContext(wavm->compartment_);
   for (auto& p : intrinsicModuleInstances_) {
     wavm->intrinsicModuleInstances_.emplace(
@@ -395,8 +393,6 @@ void Wavm::link(absl::string_view name, bool needs_emscripten) {
                                       std::string(name));
   memory_ = getDefaultMemory(moduleInstance_);
   memory_base_ = WAVM::Runtime::getMemoryBaseAddress(memory_);
-  memory_size_ = WAVM::Runtime::getMemoryMaxPages(memory_);
-  memory_size_ *= wasmPageSize;
   getInstantiatedGlobals();
 }
 
@@ -446,6 +442,8 @@ void Wavm::start(Context* context) {
   }
 }
 
+uint64_t Wavm::getMemorySize() { return WAVM::Runtime::getMemoryNumPages(memory_) * wasmPageSize; }
+
 absl::string_view Wavm::getMemory(uint64_t pointer, uint64_t size) {
   return {reinterpret_cast<char*>(
               WAVM::Runtime::memoryArrayPtr<U8>(memory_, pointer, static_cast<U64>(size))),
@@ -457,7 +455,7 @@ bool Wavm::getMemoryOffset(void* host_pointer, uint64_t* vm_pointer) {
   if (offset < 0) {
     return false;
   }
-  if (static_cast<size_t>(offset) > memory_size_) {
+  if (static_cast<size_t>(offset) > WAVM::Runtime::getMemoryNumPages(memory_) * wasmPageSize) {
     return false;
   }
   *vm_pointer = static_cast<uint64_t>(offset);


### PR DESCRIPTION
While there, remove some code that assumed never-changing heap size.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>