### PR TITLE
wasm: use values extracted from Emscripten metadata.

### DIFF
--- a/source/extensions/common/wasm/null/null.cc
+++ b/source/extensions/common/wasm/null/null.cc
@@ -58,7 +58,7 @@ struct NullVm : public WasmVm {
   std::unique_ptr<WasmVm> clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;
   void link(absl::string_view debug_name, bool needs_emscripten) override;
-  void setMemoryLayout(uint64_t, uint64_t) override {}
+  void setMemoryLayout(uint64_t, uint64_t, uint64_t) override {}
   void start(Common::Wasm::Context* context) override;
   uint64_t getMemorySize() override;
   absl::string_view getMemory(uint64_t pointer, uint64_t size) override;

--- a/source/extensions/common/wasm/null/null.cc
+++ b/source/extensions/common/wasm/null/null.cc
@@ -58,6 +58,7 @@ struct NullVm : public WasmVm {
   std::unique_ptr<WasmVm> clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;
   void link(absl::string_view debug_name, bool needs_emscripten) override;
+  void setMemoryLayout(uint64_t, uint64_t) override {}
   void start(Common::Wasm::Context* context) override;
   uint64_t getMemorySize() override;
   absl::string_view getMemory(uint64_t pointer, uint64_t size) override;

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -499,11 +499,11 @@ Word _emscripten_resize_heapHandler(void*, Word) {
   throw WasmException("emscripten emscripten_resize_heap");
 }
 
-Word abortOnCannotGrowMemoryabi0_0Handler(void*) {
+Word abortOnCannotGrowMemoryAbi00Handler(void*) {
   throw WasmException("emscripten abortOnCannotGrowMemory");
 }
 
-Word abortOnCannotGrowMemoryabi0_2Handler(void*, Word) {
+Word abortOnCannotGrowMemoryAbi02Handler(void*, Word) {
   throw WasmException("emscripten abortOnCannotGrowMemory");
 }
 
@@ -1339,9 +1339,9 @@ void Wasm::registerCallbacks() {
   if (is_emscripten_) {
     if (emscripten_abi_major_version_ > 0 || emscripten_abi_minor_version_ > 1) {
       // abi 0.2 - abortOnCannotGrowMemory() changed singature to (param i32) (result i32).
-      _REGISTER_ABI(abortOnCannotGrowMemory, abi0_2);
+      _REGISTER_ABI(abortOnCannotGrowMemory, Abi02);
     } else {
-      _REGISTER_ABI(abortOnCannotGrowMemory, abi0_0);
+      _REGISTER_ABI(abortOnCannotGrowMemory, Abi00);
     }
 
     _REGISTER(_emscripten_memcpy_big);

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -499,7 +499,11 @@ Word _emscripten_resize_heapHandler(void*, Word) {
   throw WasmException("emscripten emscripten_resize_heap");
 }
 
-Word abortOnCannotGrowMemoryHandler(void*) {
+Word abortOnCannotGrowMemoryabi0_0Handler(void*) {
+  throw WasmException("emscripten abortOnCannotGrowMemory");
+}
+
+Word abortOnCannotGrowMemoryabi0_2Handler(void*, Word) {
   throw WasmException("emscripten abortOnCannotGrowMemory");
 }
 
@@ -1324,16 +1328,24 @@ Wasm::Wasm(absl::string_view vm, absl::string_view id, absl::string_view initial
 }
 
 void Wasm::registerCallbacks() {
-#define _REGISTER(_fn)                                                                             \
+#define _REGISTER_ABI(_fn, _abi)                                                                   \
   wasm_vm_->registerCallback(                                                                      \
-      "envoy", #_fn, &_fn##Handler,                                                                \
-      &ConvertFunctionWordToUint32<decltype(_fn##Handler),                                         \
-                                   _fn##Handler>::convertFunctionWordToUint32);
+      "envoy", #_fn, &_fn##_abi##Handler,                                                          \
+      &ConvertFunctionWordToUint32<decltype(_fn##_abi##Handler),                                   \
+                                   _fn##_abi##Handler>::convertFunctionWordToUint32)
+#define _REGISTER(_fn) _REGISTER_ABI(_fn, )
+
   if (is_emscripten_) {
+    if (emscripten_abi_major_version_ > 0 || emscripten_abi_minor_version_ > 1) {
+      // abi 0.2 - abortOnCannotGrowMemory() changed singature to (param i32) (result i32).
+      _REGISTER_ABI(abortOnCannotGrowMemory, abi0_2);
+    } else {
+      _REGISTER_ABI(abortOnCannotGrowMemory, abi0_0);
+    }
+
     _REGISTER(_emscripten_memcpy_big);
     _REGISTER(_emscripten_get_heap_size);
     _REGISTER(_emscripten_resize_heap);
-    _REGISTER(abortOnCannotGrowMemory);
     _REGISTER(abort);
     _REGISTER(_abort);
     _REGISTER(_llvm_trap);
@@ -1360,6 +1372,7 @@ void Wasm::registerCallbacks() {
     _REGISTER(setTempRet0);
   }
 #undef _REGISTER
+#undef _REGISTER_ABI
 
   // Calls with the "_proxy_" prefix.
 #define _REGISTER_PROXY(_fn)                                                                       \
@@ -1414,12 +1427,13 @@ void Wasm::registerCallbacks() {
 
 void Wasm::establishEnvironment() {
   if (is_emscripten_) {
-    emscripten_table_base_ = wasm_vm_->makeGlobal("env", "__table_base", Word(0));
-    emscripten_dynamictop_ = wasm_vm_->makeGlobal("env", "DYNAMICTOP_PTR", Word(128 * 64 * 1024));
+    global_table_base_ = wasm_vm_->makeGlobal("env", "__table_base", Word(0));
+    global_dynamictop_ =
+        wasm_vm_->makeGlobal("env", "DYNAMICTOP_PTR", Word(emscripten_dynamictop_ptr_));
 
     wasm_vm_->makeModule("global");
-    emscripten_NaN_ = wasm_vm_->makeGlobal("global", "NaN", std::nan("0"));
-    emscripten_Infinity_ =
+    global_NaN_ = wasm_vm_->makeGlobal("global", "NaN", std::nan("0"));
+    global_Infinity_ =
         wasm_vm_->makeGlobal("global", "Infinity", std::numeric_limits<double>::infinity());
   }
 }
@@ -1480,12 +1494,19 @@ bool Wasm::initialize(const std::string& code, absl::string_view name, bool allo
     is_emscripten_ = true;
     auto start = reinterpret_cast<const uint8_t*>(metadata.data());
     auto end = reinterpret_cast<const uint8_t*>(metadata.data() + metadata.size());
-    start = decodeVarint(start, end, &emscripten_major_version_);
-    start = decodeVarint(start, end, &emscripten_minor_version_);
+    start = decodeVarint(start, end, &emscripten_metadata_major_version_);
+    start = decodeVarint(start, end, &emscripten_metadata_minor_version_);
     start = decodeVarint(start, end, &emscripten_abi_major_version_);
     start = decodeVarint(start, end, &emscripten_abi_minor_version_);
     start = decodeVarint(start, end, &emscripten_memory_size_);
-    decodeVarint(start, end, &emscripten_table_size_);
+    start = decodeVarint(start, end, &emscripten_table_size_);
+    if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 0) {
+      // metadata 0.1 - added: global_base, dynamic_base, dynamictop_ptr and tempdouble_ptr.
+      start = decodeVarint(start, end, &emscripten_global_base_);
+      start = decodeVarint(start, end, &emscripten_dynamic_base_);
+      start = decodeVarint(start, end, &emscripten_dynamictop_ptr_);
+      decodeVarint(start, end, &emscripten_tempdouble_ptr_);
+    }
   }
   registerCallbacks();
   establishEnvironment();
@@ -1493,8 +1514,8 @@ bool Wasm::initialize(const std::string& code, absl::string_view name, bool allo
   general_context_ = createContext();
   wasm_vm_->start(general_context_.get());
   if (is_emscripten_) {
-    ASSERT(std::isnan(emscripten_NaN_->get()));
-    ASSERT(std::isinf(emscripten_Infinity_->get()));
+    ASSERT(std::isnan(global_NaN_->get()));
+    ASSERT(std::isinf(global_Infinity_->get()));
   }
   code_ = code;
   allow_precompiled_ = allow_precompiled;

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -1427,6 +1427,8 @@ void Wasm::registerCallbacks() {
 
 void Wasm::establishEnvironment() {
   if (is_emscripten_) {
+    wasm_vm_->setMemoryLayout(emscripten_dynamic_base_, emscripten_dynamictop_ptr_);
+
     global_table_base_ = wasm_vm_->makeGlobal("env", "__table_base", Word(0));
     global_dynamictop_ =
         wasm_vm_->makeGlobal("env", "DYNAMICTOP_PTR", Word(emscripten_dynamictop_ptr_));

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -670,6 +670,7 @@ private:
   uint32_t emscripten_memory_size_ = 0;
   uint32_t emscripten_table_size_ = 0;
   uint32_t emscripten_global_base_ = 0;
+  uint32_t emscripten_stack_base_ = 0;
   uint32_t emscripten_dynamic_base_ = 0;
   uint32_t emscripten_dynamictop_ptr_ = 0;
   uint32_t emscripten_tempdouble_ptr_ = 0;
@@ -709,7 +710,8 @@ public:
   virtual void link(absl::string_view debug_name, bool needs_emscripten) PURE;
 
   // Set memory layout (start of dynamic heap base, etc.) in the VM.
-  virtual void setMemoryLayout(uint64_t heap_base, uint64_t heap_base_pointer) PURE;
+  virtual void setMemoryLayout(uint64_t stack_base, uint64_t heap_base,
+                               uint64_t heap_base_pointer) PURE;
 
   // Call the 'start' function and initialize globals.
   virtual void start(Context*) PURE;

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -708,6 +708,9 @@ public:
   // Link to registered function.
   virtual void link(absl::string_view debug_name, bool needs_emscripten) PURE;
 
+  // Set memory layout (start of dynamic heap base, etc.) in the VM.
+  virtual void setMemoryLayout(uint64_t heap_base, uint64_t heap_base_pointer) PURE;
+
   // Call the 'start' function and initialize globals.
   virtual void start(Context*) PURE;
 

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -562,14 +562,15 @@ public:
     general_context_ = std::move(context);
   }
 
-  bool getEmscriptenVersion(uint32_t* emscripten_major_version, uint32_t* emscripten_minor_version,
+  bool getEmscriptenVersion(uint32_t* emscripten_metadata_major_version,
+                            uint32_t* emscripten_metadata_minor_version,
                             uint32_t* emscripten_abi_major_version,
                             uint32_t* emscripten_abi_minor_version) {
     if (!is_emscripten_) {
       return false;
     }
-    *emscripten_major_version = emscripten_major_version_;
-    *emscripten_minor_version = emscripten_minor_version_;
+    *emscripten_metadata_major_version = emscripten_metadata_major_version_;
+    *emscripten_metadata_minor_version = emscripten_metadata_minor_version_;
     *emscripten_abi_major_version = emscripten_abi_major_version_;
     *emscripten_abi_minor_version = emscripten_abi_minor_version_;
     return true;
@@ -662,17 +663,21 @@ private:
   bool allow_precompiled_ = false;
 
   bool is_emscripten_ = false;
-  uint32_t emscripten_major_version_ = 0;
-  uint32_t emscripten_minor_version_ = 0;
+  uint32_t emscripten_metadata_major_version_ = 0;
+  uint32_t emscripten_metadata_minor_version_ = 0;
   uint32_t emscripten_abi_major_version_ = 0;
   uint32_t emscripten_abi_minor_version_ = 0;
   uint32_t emscripten_memory_size_ = 0;
   uint32_t emscripten_table_size_ = 0;
+  uint32_t emscripten_global_base_ = 0;
+  uint32_t emscripten_dynamic_base_ = 0;
+  uint32_t emscripten_dynamictop_ptr_ = 0;
+  uint32_t emscripten_tempdouble_ptr_ = 0;
 
-  std::unique_ptr<Global<Word>> emscripten_table_base_;
-  std::unique_ptr<Global<Word>> emscripten_dynamictop_;
-  std::unique_ptr<Global<double>> emscripten_NaN_;
-  std::unique_ptr<Global<double>> emscripten_Infinity_;
+  std::unique_ptr<Global<Word>> global_table_base_;
+  std::unique_ptr<Global<Word>> global_dynamictop_;
+  std::unique_ptr<Global<double>> global_NaN_;
+  std::unique_ptr<Global<double>> global_Infinity_;
 
   // Stats/Metrics
   uint32_t next_counter_metric_id_ = kMetricTypeCounter;

--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -236,6 +236,7 @@ struct Wavm : public WasmVm {
   bool clonable() override { return true; };
   std::unique_ptr<WasmVm> clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;
+  void setMemoryLayout(uint64_t, uint64_t) override {}
   void link(absl::string_view debug_name, bool needs_emscripten) override;
   void start(Context* context) override;
   uint64_t getMemorySize() override;

--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -236,7 +236,7 @@ struct Wavm : public WasmVm {
   bool clonable() override { return true; };
   std::unique_ptr<WasmVm> clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;
-  void setMemoryLayout(uint64_t, uint64_t) override {}
+  void setMemoryLayout(uint64_t, uint64_t, uint64_t) override {}
   void link(absl::string_view debug_name, bool needs_emscripten) override;
   void start(Context* context) override;
   uint64_t getMemorySize() override;


### PR DESCRIPTION
This allows us to use more recent versions of Emscripten.

Fixes envoyproxy/envoy-wasm#32.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>