### PR TITLE
Switch onDelete and onDone call

### DIFF
--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -1558,14 +1558,14 @@ void Context::log(const Http::HeaderMap* request_headers, const Http::HeaderMap*
   access_log_response_headers_ = nullptr;
   access_log_stream_info_ = nullptr;
 
-  onDelete();
+  onDone();
 }
 
 void Context::onDestroy() {
   if (destroyed_)
     return;
   destroyed_ = true;
-  onDone();
+  onDelete();
 }
 
 void Context::onDone() {

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -296,7 +296,7 @@ public:
   // Async Response Downcalls on any Context.
   virtual void onHttpCallResponse(uint32_t token, const Pairs& response_headers,
                                   absl::string_view response_body, const Pairs& response_trailers);
-  // General stream downcall when no futher stream calls will occur.
+  // General stream downcall when no further stream calls will occur.
   virtual void onDone();
   // General stream downcall for logging. Occurs after onDone().
   virtual void onLog();

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -296,11 +296,11 @@ public:
   // Async Response Downcalls on any Context.
   virtual void onHttpCallResponse(uint32_t token, const Pairs& response_headers,
                                   absl::string_view response_body, const Pairs& response_trailers);
-  // General stream downcall when the stream has ended.
+  // General stream downcall when no futher stream calls will occur.
   virtual void onDone();
   // General stream downcall for logging. Occurs after onDone().
   virtual void onLog();
-  // General stream downcall when no futher stream calls will occur.
+  // General stream downcall when the stream has ended.
   virtual void onDelete();
 
   //


### PR DESCRIPTION
It feels to me that onDone() should be called at the end of log callback which means on more callback is going to be triggered, and onDelete should be called in onDesdroy when filter is deleted. This would make code fit better with the semantic.

@jplevyak @PiotrSikora Feel free to close this PR if the original way is preferred. Thanks!