### PR TITLE
fix get context base

### DIFF
--- a/api/wasm/cpp/proxy_wasm_intrinsics.cc
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.cc
@@ -66,7 +66,7 @@ static RootContext* ensureRootContext(uint32_t context_id, std::unique_ptr<WasmD
 
 static ContextBase* getContextBase(uint32_t context_id) {
   auto it = context_map.find(context_id);
-  if (it == context_map.end() || !it->second->asContext()) {
+  if (it == context_map.end() || !(it->second->asContext() || it->second->asRoot())) {
     throw ProxyException("no base context context_id: " + std::to_string(context_id));
   }
   return it->second.get();


### PR DESCRIPTION
This causes grpc callback on root context fail.
@PiotrSikora 

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
