### PR TITLE
Add proxy_sendLocalReply to the intrinsic functions.

### DIFF
--- a/api/wasm/cpp/proxy_wasm_intrinsics.js
+++ b/api/wasm/cpp/proxy_wasm_intrinsics.js
@@ -37,4 +37,5 @@ mergeInto(LibraryManager.library, {
     proxy_grpcSend : function () {},
     proxy_grpcClose : function () {},
     proxy_grpcCancel : function () {},
+    proxy_sendLocalResponse : function () {},
 });


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: wasm: Make the function proxy_sendLocalReply available as an intrinsic function to WebAssembly
Risk Level: Low
Testing: Compiled a module that contains a call to the function `sendLocalReply()`.
Docs Changes: none
Release Notes: none
[Optional Fixes #Issue]
[Optional Deprecated:]

Currently after changing the envoy_filter_http_wasm_example.cc by adding a call to `sendLocalReply()` make fails with this error:
```
em++ -s WASM=1 -s BINARYEN_TRAP_MODE='clamp' -s LEGALIZE_JS_FFI=0 -s EMIT_EMSCRIPTEN_METADATA=1 --std=c++17 -O3 -g3 -DEMSCRIPTEN_PROTOBUF_LITE=1 -I/Users/rpanzer/dev/envoy-wasm/api/wasm/cpp -I/Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/google/protobuf -I/usr/local/include --js-library /Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/proxy_wasm_intrinsics.js envoy_filter_http_wasm_example.cc /Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/proxy_wasm_intrinsics_lite.pb.cc /Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/struct_lite.pb.cc /Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/proxy_wasm_intrinsics.cc /Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/libprotobuf-lite.bc -o envoy_filter_http_wasm_example.js
error: undefined symbol: proxy_sendLocalResponse
warning: To disable errors for undefined symbols use `-s ERROR_ON_UNDEFINED_SYMBOLS=0`
Error: Aborting compilation due to previous errors
shared:ERROR: '/Users/rpanzer/dev/wasm-examples/emsdk/node/8.9.1_64bit/bin/node /Users/rpanzer/dev/wasm-examples/emsdk/emscripten/1.38.25/src/compiler.js /tmp/tmpNQ5S_V.txt /Users/rpanzer/dev/envoy-wasm/api/wasm/cpp/proxy_wasm_intrinsics.js /Users/rpanzer/dev/wasm-examples/emsdk/emscripten/1.38.25/src/library_pthread_stub.js' failed (1)
make: *** [envoy_filter_http_wasm_example.wasm] Error 1
```

This seems to come from `proxy_sendLocalResponse` not being defined in the `proxy_wasm_intrinsics.js`.
This PR adds this function to the list.

Another way to workaround this is to add the option to ignore missing symbols. The compiled module also seems to run, but I think it should be possible to build without warnings.