### PR TITLE
Fix null plugin name

### DIFF
--- a/source/extensions/common/wasm/null/null_vm.cc
+++ b/source/extensions/common/wasm/null/null_vm.cc
@@ -25,6 +25,7 @@ bool NullVm::load(const std::string& name, bool /* allow_precompiled */) {
   if (!factory) {
     return false;
   }
+  plugin_name_ = name;
   plugin_ = factory->create();
   return true;
 }


### PR DESCRIPTION
This causes panic when load thread local instance from the base instance. See test failure here: https://github.com/istio/proxy/pull/2359 @jplevyak @PiotrSikora 

Do we have any test for null plugin?