### PR TITLE
Prometheus scraper: Opt out of automatic namespacing

### DIFF
--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -833,6 +833,12 @@ std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag
 }
 
 std::string PrometheusStatsFormatter::metricName(const std::string& extractedName) {
+  // Offer a way to opt out of automatic namespacing.
+  // If metric name starts with "_" it will be trimmed but not namespaced.
+  // It is the responsibility of the metric creator to ensure proper namespacing.
+  if (extractedName.size() > 1 && extractedName[0] == '_') {
+    return sanitizeName(extractedName.substr(1));
+  }
   // Add namespacing prefix to avoid conflicts, as per best practice:
   // https://prometheus.io/docs/practices/naming/#metric-names
   // Also, naming conventions on https://prometheus.io/docs/concepts/data_model/

--- a/test/server/http/admin_test.cc
+++ b/test/server/http/admin_test.cc
@@ -1410,6 +1410,13 @@ TEST_F(PrometheusStatsFormatterTest, MetricName) {
   EXPECT_EQ(expected, actual);
 }
 
+TEST_F(PrometheusStatsFormatterTest, MetricNameOptOut) {
+  std::string raw = "_vulture.eats-liver";
+  std::string expected = "vulture_eats_liver";
+  auto actual = PrometheusStatsFormatter::metricName(raw);
+  EXPECT_EQ(expected, actual);
+}
+
 TEST_F(PrometheusStatsFormatterTest, SanitizeMetricName) {
   std::string raw = "An.artist.plays-violin@019street";
   std::string expected = "envoy_An_artist_plays_violin_019street";


### PR DESCRIPTION
Description:
All prometheus metrics emitted from envoy automatically get namespaced under `envoy_`.

Risk Level: 
Testing:
Unit tests.

Docs Changes:
Release Notes:
Fixes https://github.com/envoyproxy/envoy/issues/7957

