### PR TITLE
build: drop GLib2 dependency in wee8.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   ubuntu-build:
     description: "A regular build executor based on ubuntu image"
     docker:
-      - image: piotrsikora/envoy:d799827e285e2f4f42f4ecf284ff4cc999f48e35
+      - image: envoyproxy/envoy-build:cd8574de783791b3353579b489222bfda74888da
     resource_class: xlarge
     working_directory: /source
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ executors:
   ubuntu-build:
     description: "A regular build executor based on ubuntu image"
     docker:
-      - image: envoyproxy/envoy-build:cd8574de783791b3353579b489222bfda74888da
+      - image: piotrsikora/envoy:d799827e285e2f4f42f4ecf284ff4cc999f48e35
     resource_class: xlarge
     working_directory: /source
 

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -16,7 +16,7 @@ pushd $$ROOT/wee8
 rm -rf out/wee8
 
 # Build wee8.
-AR=ar NM=nm third_party/depot_tools/gn gen out/wee8 --args='v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_expose_symbols=true is_component_build=false is_debug=false clang_use_chrome_plugins=false use_sysroot=false use_custom_libcxx=false custom_toolchain="//build/toolchain/linux/unbundle:default"'
+AR=ar NM=nm third_party/depot_tools/gn gen out/wee8 --args='v8_use_external_startup_data=false v8_enable_i18n_support=false v8_enable_gdbjit=false v8_expose_symbols=true is_component_build=false is_debug=false clang_use_chrome_plugins=false use_sysroot=false use_custom_libcxx=false use_glib=false custom_toolchain="//build/toolchain/linux/unbundle:default"'
 third_party/depot_tools/ninja -C out/wee8 wee8
 
 # Move compiled library to the expected destinations.

--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -6,10 +6,9 @@ set -e
 yum install -y centos-release-scl epel-release
 yum update -y
 yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-1.8.0-openjdk-headless rsync \
-    rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
+    rh-git218 wget unzip which make patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
     libtool autoconf tcpdump
 
-ln -s /usr/bin/cmake3 /usr/bin/cmake
 ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 # SLES 11 has older glibc than CentOS 7, so pre-built binary for it works on CentOS 7

--- a/ci/build_container/build_container_centos.sh
+++ b/ci/build_container/build_container_centos.sh
@@ -6,8 +6,11 @@ set -e
 yum install -y centos-release-scl epel-release
 yum update -y
 yum install -y devtoolset-7-gcc devtoolset-7-gcc-c++ devtoolset-7-binutils java-1.8.0-openjdk-headless rsync \
-    rh-git218 wget unzip which make patch devtoolset-7-libatomic-devel openssl python27 \
-    libtool autoconf tcpdump glib2-devel
+    rh-git218 wget unzip which make cmake3 patch ninja-build devtoolset-7-libatomic-devel openssl python27 \
+    libtool autoconf tcpdump
+
+ln -s /usr/bin/cmake3 /usr/bin/cmake
+ln -s /usr/bin/ninja-build /usr/bin/ninja
 
 # SLES 11 has older glibc than CentOS 7, so pre-built binary for it works on CentOS 7
 LLVM_VERSION=8.0.0

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -14,4 +14,11 @@ if [[ "$(uname -m)" == "x86_64" ]]; then
   curl --location --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION}/bazelisk-linux-amd64 \
     && echo "$SHA256  /usr/local/bin/bazel" | sha256sum --check \
     && chmod +x /usr/local/bin/bazel
+
+  # CMake
+  VERSION=3.14.5
+  SHA256=757e7ddd29d11422334a60d7cd9c19b7af20349a03cb15aa3c879f1b54193c95
+  curl -sLo cmake-"$VERSION".tar.gz https://github.com/Kitware/CMake/releases/download/v"$VERSION"/cmake-"$VERSION"-Linux-x86_64.tar.gz \
+    && echo "$SHA256" cmake-"$VERSION".tar.gz | sha256sum --check \
+    && tar -zxf cmake-"$VERSION".tar.gz -C /usr --strip-components=1
 fi

--- a/ci/build_container/build_container_common.sh
+++ b/ci/build_container/build_container_common.sh
@@ -14,19 +14,4 @@ if [[ "$(uname -m)" == "x86_64" ]]; then
   curl --location --output /usr/local/bin/bazel https://github.com/bazelbuild/bazelisk/releases/download/v${VERSION}/bazelisk-linux-amd64 \
     && echo "$SHA256  /usr/local/bin/bazel" | sha256sum --check \
     && chmod +x /usr/local/bin/bazel
-
-  # CMake
-  VERSION=3.14.5
-  SHA256=757e7ddd29d11422334a60d7cd9c19b7af20349a03cb15aa3c879f1b54193c95
-  curl -sLo cmake-"$VERSION".tar.gz https://github.com/Kitware/CMake/releases/download/v"$VERSION"/cmake-"$VERSION"-Linux-x86_64.tar.gz \
-    && echo "$SHA256" cmake-"$VERSION".tar.gz | sha256sum --check \
-    && tar -zxf cmake-"$VERSION".tar.gz -C /usr --strip-components=1
-
-  # ninja
-  VERSION=1.8.2
-  SHA256=d2fea9ff33b3ef353161ed906f260d565ca55b8ca0568fa07b1d2cab90a84a07
-  curl -sLo ninja-"$VERSION".zip https://github.com/ninja-build/ninja/releases/download/v"$VERSION"/ninja-linux.zip \
-    && echo "$SHA256" ninja-"$VERSION".zip | sha256sum --check \
-    && unzip ninja-"$VERSION".zip \
-    && mv ninja /usr/bin
 fi

--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -18,7 +18,7 @@ update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 1000
 update-alternatives --config gcc
 update-alternatives --config g++
 
-apt-get install -y --no-install-recommends curl wget make cmake git python python-pip python-setuptools python3 python3-pip \
+apt-get install -y --no-install-recommends curl wget make git python python-pip python-setuptools python3 python3-pip \
   unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client
 
 # clang 8.

--- a/ci/build_container/build_container_ubuntu.sh
+++ b/ci/build_container/build_container_ubuntu.sh
@@ -18,8 +18,8 @@ update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 1000
 update-alternatives --config gcc
 update-alternatives --config g++
 
-apt-get install -y --no-install-recommends curl wget make git python python-pip python-setuptools python3 python3-pip \
-  unzip bc libtool automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client libglib2.0-dev
+apt-get install -y --no-install-recommends curl wget make cmake git python python-pip python-setuptools python3 python3-pip \
+  unzip bc libtool ninja-build automake zip time gdb strace tshark tcpdump patch xz-utils rsync ssh-client
 
 # clang 8.
 case $ARCH in


### PR DESCRIPTION
Suggested by Lizan in:
https://github.com/envoyproxy/envoy-wasm/pull/152

Signed-off-by: Piotr Sikora <piotrsikora@google.com>