### PR TITLE
use filter state for storing shared filter state

### DIFF
--- a/api/wasm/cpp/proxy_wasm_api.h
+++ b/api/wasm/cpp/proxy_wasm_api.h
@@ -466,78 +466,6 @@ inline bool ContextBase::isProactivelyCachable(MetadataType type) {
   }
 }
 
-// Expressions
-
-#define PROXY_EXPRESSION_GET_STRING(_expression, _string_ptr) do { \
-  const char* _value_ptr = nullptr; \
-  size_t _value_size = 0; \
-  auto _result = static_cast<WasmResult>(proxy_getMetadata(MetadataType::Expression, _expression, sizeof(_expression)-1, &_value_ptr, &_value_size)); \
-  if (_result != WasmResult::Ok) { \
-    _string_ptr->clear(); \
-    return _result; \
-  } \
-  _string_ptr->assign(_value_ptr, _value_size); \
-  return WasmResult::Ok; \
-} while(0)
-
-#define PROXY_EXPRESSION_GET(_expression, _data_ptr) do { \
-  const char* _value_ptr = nullptr; \
-  size_t _value_size = 0; \
-  auto _result = static_cast<WasmResult>(proxy_getMetadata(MetadataType::Expression, _expression, sizeof(_expression)-1, &_value_ptr, &_value_size)); \
-  if (_result != WasmResult::Ok) { \
-    return _result; \
-  } \
-  if (_value_size != sizeof(*_data_ptr)) { \
-    return WasmResult::ResultMismatch; \
-  } \
-  memcpy(_data_ptr, _value_ptr, sizeof(*_data_ptr)); \
-  return WasmResult::Ok; \
-} while(0)
-
-inline WasmResult getRequestProtocol(std::string *protocol_ptr) {
-  PROXY_EXPRESSION_GET_STRING("request.protocol", protocol_ptr);
-}
-
-inline WasmResult getResponseProtocol(std::string *protocol_ptr) {
-  PROXY_EXPRESSION_GET_STRING("response.protocol", protocol_ptr);
-}
-
-inline WasmResult getRequestDestinationPort(uint32_t* port) {
-  PROXY_EXPRESSION_GET("request.destination_port", port);
-}
-
-inline WasmResult getResponseDestinationPort(uint32_t* port) {
-  PROXY_EXPRESSION_GET("response.destination_port", port);
-}
-
-inline WasmResult getRequestResponseCode(uint32_t* response_code) {
-  PROXY_EXPRESSION_GET("request.response_code", response_code);
-}
-
-inline WasmResult getResponseResponseCode(uint32_t* response_code) {
-  PROXY_EXPRESSION_GET("response.response_code", response_code);
-}
-
-inline WasmResult getRequestTlsVersion(std::string *tls_version_ptr) {
-  PROXY_EXPRESSION_GET_STRING("request.tls_version", tls_version_ptr);
-}
-
-inline WasmResult getResponseTlsVersion(std::string *tls_version_ptr) {
-  PROXY_EXPRESSION_GET_STRING("response.tls_version", tls_version_ptr);
-}
-
-inline WasmResult getRequestPeerCertificatePresented(bool *peer_certificate_presented) {
-  PROXY_EXPRESSION_GET("request.peer_certificate_presented", peer_certificate_presented);
-}
-
-inline WasmResult getResponsePeerCertificatePresented(bool *peer_certificate_presented) {
-  PROXY_EXPRESSION_GET("response.peer_certificate_presented", peer_certificate_presented);
-}
-
-inline WasmResult getPluginDirection(PluginDirection *direction_ptr) {
-  PROXY_EXPRESSION_GET("plugin.direction", reinterpret_cast<uint32_t*>(direction_ptr));
-}
-
 // Generic selector
 inline Optional<WasmDataPtr> getSelectorExpression(std::initializer_list<StringView> parts) {
   size_t size = 0;
@@ -603,23 +531,18 @@ inline WasmResult getMetadataStringValue(MetadataType type, StringView key, std:
   return result;
 }
 
-inline WasmResult setMetadata(MetadataType type, StringView key, StringView value) {
-  return static_cast<WasmResult>(proxy_setMetadata(type, key.data(), key.size(), value.data(), value.size()));
-}
-
-inline WasmResult setMetadataValue(MetadataType type, StringView key,
-                                       const google::protobuf::Value& value) {
+inline WasmResult setStateValue(StringView key, const google::protobuf::Value& value) {
   std::string output;
   if (!value.SerializeToString(&output)) {
     return WasmResult::SerializationFailure;
   }
-  return static_cast<WasmResult>(proxy_setMetadata(type, key.data(), key.size(), output.data(), output.size()));
+  return static_cast<WasmResult>(proxy_setState(key.data(), key.size(), output.data(), output.size()));
 }
 
-inline WasmResult setMetadataStringValue(MetadataType type, StringView key, StringView s) {
+inline WasmResult setStateStringValue(StringView key, StringView s) {
   google::protobuf::Value value;
   value.set_string_value(s.data(), s.size());
-  return setMetadataValue(type, key, value);
+  return setStateValue(key, value);
 }
 
 inline WasmResult getMetadataValuePairs(MetadataType type, WasmDataPtr* pairs_ptr) {
@@ -648,15 +571,6 @@ inline WasmResult getMetadataStruct(MetadataType type, StringView name, google::
   }
   *struct_ptr = s;
   return WasmResult::Ok;
-}
-
-inline WasmResult setMetadataStruct(MetadataType type, StringView name,
-                                        const google::protobuf::Struct& s) {
-  std::string output;
-  if (!s.SerializeToString(&output)) {
-    return WasmResult::SerializationFailure;
-  }
-  return static_cast<WasmResult>(proxy_setMetadataStruct(type, name.data(), name.size(), output.data(), output.size()));
 }
 
 inline WasmResult ContextBase::metadataValue(MetadataType type, StringView key, google::protobuf::Value* value_ptr) {

--- a/api/wasm/cpp/proxy_wasm_externs.h
+++ b/api/wasm/cpp/proxy_wasm_externs.h
@@ -63,14 +63,12 @@ extern "C" WasmResult proxy_getCurrentTimeNanoseconds(uint64_t* nanoseconds);
 // Metadata
 extern "C" WasmResult proxy_getMetadata(MetadataType type, const char* key_ptr, size_t key_size,
                                       const char** value_ptr_ptr, size_t* value_size_ptr);
-extern "C" WasmResult proxy_setMetadata(MetadataType type, const char* key_ptr, size_t key_size,
-                                      const char* value_ptr, size_t value_size);
 extern "C" WasmResult proxy_getMetadataPairs(MetadataType type, const char** value_ptr,
                                            size_t* value_size);
 extern "C" WasmResult proxy_getMetadataStruct(MetadataType type, const char* name_ptr, size_t name_size,
                                             const char** value_ptr_ptr, size_t* value_size_ptr);
-extern "C" WasmResult proxy_setMetadataStruct(MetadataType type, const char* name_ptr, size_t name_size,
-                                            const char* value_ptr, size_t value_size);
+extern "C" WasmResult proxy_setState(const char* key_ptr, size_t key_size,
+                                     const char* value_ptr, size_t value_size);
 
 // Generic selector
 extern "C" WasmResult proxy_getSelectorExpression(const char* path_ptr, size_t path_size,

--- a/api/wasm/cpp/proxy_wasm_metadata.h
+++ b/api/wasm/cpp/proxy_wasm_metadata.h
@@ -44,9 +44,3 @@ enum class HeaderMapType : int32_t {
   GrpcReceiveTrailingMetadata = 6,  // Immutable
   MAX = 6,
 };
-
-enum class PluginDirection : int32_t {
-  Unspecified = 0,
-  Inbound = 1,
-  Outbound = 2,
-};

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -35,8 +35,7 @@ WasmAccessLogFactory::createAccessLogInstance(const Protobuf::Message& proto_con
     // individual threads.
     auto base_wasm = Common::Wasm::createWasm(
         vm_id, config.vm_config(), root_id, context.clusterManager(), context.dispatcher(),
-        context.api(), context.scope(),
-        Common::Wasm::pluginDirectionFromTrafficDirection(context.direction()), context.localInfo(),
+        context.api(), context.scope(), context.direction(), context.localInfo(),
         &context.listenerMetadata(), nullptr /* owned_scope */);
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot->set([base_wasm, root_id, configuration](Event::Dispatcher& dispatcher) {

--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -79,5 +79,6 @@ envoy_cc_library(
         "@com_google_cel_cpp//eval/eval:field_access",
         "@com_google_cel_cpp//eval/eval:field_backed_list_impl",
         "@com_google_cel_cpp//eval/eval:field_backed_map_impl",
+        "@com_google_cel_cpp//eval/public:cel_value",
     ],
 )

--- a/source/extensions/common/wasm/null/sample_plugin/plugin.cc
+++ b/source/extensions/common/wasm/null/sample_plugin/plugin.cc
@@ -45,6 +45,7 @@ FilterDataStatus PluginContext::onRequestBody(size_t body_buffer_length, bool /*
 }
 
 void PluginContext::onLog() {
+  setStateStringValue("wasm_state", "wasm_value");
   auto path = getRequestHeader(":path");
   if (path->view() == "/test_context") {
     logWarn("request.path: " + getSelectorExpression({"request", "path"}).value()->toString());
@@ -62,6 +63,7 @@ void PluginContext::onLog() {
       int64_t code = absl::bit_cast<int64_t>(buf);
       logWarn("response.code: " + absl::StrCat(code));
     }
+    logWarn("state: " + getSelectorExpression({"filter_state", "wasm_state"}).value()->toString());
   } else {
     logWarn("onLog " + std::to_string(id()) + " " + std::string(path->view()));
   }

--- a/source/extensions/common/wasm/null/wasm_api_impl.h
+++ b/source/extensions/common/wasm/null/wasm_api_impl.h
@@ -40,10 +40,10 @@ inline WasmResult proxy_getMetadata(MetadataType type, const char* key_ptr, size
   return wordToWasmResult(getMetadataHandler(current_context_, WS(type), WR(key_ptr), WS(key_size),
                                              WR(value_ptr_ptr), WR(value_size_ptr)));
 }
-inline WasmResult proxy_setMetadata(MetadataType type, const char* key_ptr, size_t key_size,
-                                    const char* value_ptr, size_t value_size) {
-  return wordToWasmResult(setMetadataHandler(current_context_, WS(type), WR(key_ptr), WS(key_size),
-                                             WR(value_ptr), WS(value_size)));
+inline WasmResult proxy_setState(const char* key_ptr, size_t key_size, const char* value_ptr,
+                                 size_t value_size) {
+  return wordToWasmResult(
+      setStateHandler(current_context_, WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size)));
 }
 inline WasmResult proxy_getMetadataPairs(MetadataType type, const char** value_ptr,
                                          size_t* value_size) {
@@ -55,11 +55,6 @@ inline WasmResult proxy_getMetadataStruct(MetadataType type, const char* name_pt
   return wordToWasmResult(getMetadataStructHandler(current_context_, WS(type), WR(name_ptr),
                                                    WS(name_size), WR(value_ptr_ptr),
                                                    WR(value_size_ptr)));
-}
-inline WasmResult proxy_setMetadataStruct(MetadataType type, const char* name_ptr, size_t name_size,
-                                          const char* value_ptr, size_t value_size) {
-  return wordToWasmResult(setMetadataStructHandler(current_context_, WS(type), WR(name_ptr),
-                                                   WS(name_size), WR(value_ptr), WS(value_size)));
 }
 
 // Generic selector

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -35,6 +35,7 @@
 #include "eval/eval/field_access.h"
 #include "eval/eval/field_backed_list_impl.h"
 #include "eval/eval/field_backed_map_impl.h"
+#include "eval/public/cel_value.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -402,19 +403,15 @@ Word getMetadataHandler(void* raw_context, Word type, Word key_ptr, Word key_siz
   return wasmResultToWord(result);
 }
 
-Word setMetadataHandler(void* raw_context, Word type, Word key_ptr, Word key_size, Word value_ptr,
-                        Word value_size) {
-  if (type > static_cast<int>(MetadataType::MAX)) {
-    return wasmResultToWord(WasmResult::BadArgument);
-  }
+Word setStateHandler(void* raw_context, Word key_ptr, Word key_size, Word value_ptr,
+                     Word value_size) {
   auto context = WASM_CONTEXT(raw_context);
   auto key = context->wasmVm()->getMemory(key_ptr, key_size);
   auto value = context->wasmVm()->getMemory(value_ptr, value_size);
   if (!key || !value) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
-  return wasmResultToWord(
-      context->setMetadata(static_cast<MetadataType>(type.u64), key.value(), value.value()));
+  return wasmResultToWord(context->setState(key.value(), value.value()));
 }
 
 Word getMetadataPairsHandler(void* raw_context, Word type, Word ptr_ptr, Word size_ptr) {
@@ -450,21 +447,6 @@ Word getMetadataStructHandler(void* raw_context, Word type, Word name_ptr, Word 
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
   return wasmResultToWord(WasmResult::Ok);
-}
-
-Word setMetadataStructHandler(void* raw_context, Word type, Word name_ptr, Word name_size,
-                              Word value_ptr, Word value_size) {
-  if (type > static_cast<int>(MetadataType::MAX)) {
-    return Word(static_cast<uint64_t>(WasmResult::BadArgument));
-  }
-  auto context = WASM_CONTEXT(raw_context);
-  auto name = context->wasmVm()->getMemory(name_ptr, name_size);
-  auto value = context->wasmVm()->getMemory(value_ptr, value_size);
-  if (!name || !value) {
-    return wasmResultToWord(WasmResult::InvalidMemoryAccess);
-  }
-  return Word(static_cast<uint64_t>(context->setMetadataStruct(static_cast<MetadataType>(type.u64),
-                                                               name.value(), value.value())));
 }
 
 // Generic selector
@@ -1085,22 +1067,51 @@ WasmResult serializeValue(Filters::Common::Expr::CelValue value, std::string* re
     return WasmResult::Ok;
   }
   default:
-    // TODO: lists and maps
+    // TODO(kyesenov) lists and maps
     break;
   }
 
   return WasmResult::SerializationFailure;
 }
 
+// An expression wrapper for the WASM state
+class WasmStateWrapper : public google::api::expr::runtime::CelMap {
+public:
+  WasmStateWrapper(const StreamInfo::FilterState& filter_state, ProtobufWkt::Arena* arena)
+      : filter_state_(filter_state), arena_(arena) {}
+  absl::optional<google::api::expr::runtime::CelValue>
+  operator[](google::api::expr::runtime::CelValue key) const override {
+    if (!key.IsString()) {
+      return {};
+    }
+    auto value = key.StringOrDie().value();
+    try {
+      const WasmState& result = filter_state_.getDataReadOnly<WasmState>(value);
+      return google::api::expr::runtime::CelValue::CreateMessage(&result.value(), arena_);
+    } catch (const EnvoyException& e) {
+      return {};
+    }
+  }
+  int size() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  bool empty() const override { NOT_IMPLEMENTED_GCOVR_EXCL_LINE; }
+  const google::api::expr::runtime::CelList* ListKeys() const override {
+    NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
+  }
+
+private:
+  const StreamInfo::FilterState& filter_state_;
+  ProtobufWkt::Arena* arena_;
+};
+
 WasmResult Context::getSelectorExpression(absl::string_view path, std::string* result) {
-  using Filters::Common::Expr::CelValue;
+  using google::api::expr::runtime::CelValue;
   using google::api::expr::runtime::FieldBackedListImpl;
   using google::api::expr::runtime::FieldBackedMapImpl;
 
   bool first = true;
   CelValue value;
   Protobuf::Arena arena;
-  const StreamInfo::StreamInfo& info = decoder_callbacks_->streamInfo();
+  const StreamInfo::StreamInfo* info = getRequestStreamInfo();
   const auto request_headers = request_headers_ ? request_headers_ : access_log_request_headers_;
   const auto response_headers =
       response_headers_ ? response_headers_ : access_log_response_headers_;
@@ -1125,24 +1136,47 @@ WasmResult Context::getSelectorExpression(absl::string_view path, std::string* r
     if (first) {
       first = false;
       if (part == "metadata") {
-        value = CelValue::CreateMessage(&info.dynamicMetadata(), &arena);
+        value = CelValue::CreateMessage(&info->dynamicMetadata(), &arena);
+      } else if (part == "filter_state") {
+        value = CelValue::CreateMap(
+            Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState(), &arena));
       } else if (part == "request") {
         value = CelValue::CreateMap(Protobuf::Arena::Create<Filters::Common::Expr::RequestWrapper>(
-            &arena, request_headers, info));
+            &arena, request_headers, *info));
       } else if (part == "response") {
         value = CelValue::CreateMap(Protobuf::Arena::Create<Filters::Common::Expr::ResponseWrapper>(
-            &arena, response_headers, response_trailers, info));
+            &arena, response_headers, response_trailers, *info));
       } else if (part == "connection") {
         value = CelValue::CreateMap(
-            Protobuf::Arena::Create<Filters::Common::Expr::ConnectionWrapper>(&arena, info));
+            Protobuf::Arena::Create<Filters::Common::Expr::ConnectionWrapper>(&arena, *info));
       } else if (part == "node") {
         value = CelValue::CreateMessage(&wasm_->local_info_.node(), &arena);
       } else if (part == "source") {
         value = CelValue::CreateMap(
-            Protobuf::Arena::Create<Filters::Common::Expr::PeerWrapper>(&arena, info, false));
+            Protobuf::Arena::Create<Filters::Common::Expr::PeerWrapper>(&arena, *info, false));
       } else if (part == "destination") {
         value = CelValue::CreateMap(
-            Protobuf::Arena::Create<Filters::Common::Expr::PeerWrapper>(&arena, info, true));
+            Protobuf::Arena::Create<Filters::Common::Expr::PeerWrapper>(&arena, *info, true));
+      } else if (part == "tls_version") {
+        // TODO(kyessenov) move this upstream once SSL connection info is refactored to return
+        // references
+        if (info->downstreamSslConnection()) {
+          value = CelValue::CreateString(Protobuf::Arena::Create<std::string>(
+              &arena, info->downstreamSslConnection()->tlsVersion()));
+        } else {
+          return WasmResult::NotFound;
+        }
+      } else if (part == "protocol") {
+        // TODO(kyessenov) move this upstream to CEL context
+        if (info->protocol().has_value()) {
+          value =
+              CelValue::CreateString(&Http::Utility::getProtocolString(info->protocol().value()));
+        } else {
+          return WasmResult::NotFound;
+        }
+      } else if (part == "traffic_direction") {
+        // TODO(kyessenov) organize reflective accessors for the config better
+        value = CelValue::CreateInt64(wasm_->direction_);
       } else {
         return WasmResult::NotFound;
       }
@@ -1537,114 +1571,20 @@ void Context::httpRespond(const Pairs& response_headers, absl::string_view body,
 }
 
 // StreamInfo
-StreamInfo::StreamInfo* Context::getStreamInfo(MetadataType type) const {
-  switch (type) {
-  case MetadataType::Request:
-    if (decoder_callbacks_) {
-      return &decoder_callbacks_->streamInfo();
-    }
-    break;
-  case MetadataType::Response:
-    if (encoder_callbacks_) {
-      return &encoder_callbacks_->streamInfo();
-    }
-    break;
-    // Note: Log is always const.
-  default:
-    break;
+const StreamInfo::StreamInfo* Context::getRequestStreamInfo() const {
+  if (encoder_callbacks_) {
+    return &encoder_callbacks_->streamInfo();
+  } else if (decoder_callbacks_) {
+    return &decoder_callbacks_->streamInfo();
+  } else if (access_log_stream_info_) {
+    return access_log_stream_info_;
   }
   return nullptr;
-}
-
-const StreamInfo::StreamInfo* Context::getConstStreamInfo(MetadataType type) const {
-  switch (type) {
-  case MetadataType::Request:
-    if (decoder_callbacks_) {
-      return &decoder_callbacks_->streamInfo();
-    }
-    break;
-  case MetadataType::Response:
-    if (encoder_callbacks_) {
-      return &encoder_callbacks_->streamInfo();
-    }
-    break;
-  case MetadataType::Log:
-    if (access_log_stream_info_) {
-      return access_log_stream_info_;
-    }
-    break;
-  case MetadataType::Cluster:
-    if (decoder_callbacks_) {
-      return &decoder_callbacks_->streamInfo();
-    }
-    if (encoder_callbacks_) {
-      return &encoder_callbacks_->streamInfo();
-    }
-    if (access_log_stream_info_) {
-      return access_log_stream_info_;
-    }
-    break;
-  default:
-    break;
-  }
-  return nullptr;
-}
-
-std::string Context::getProtocol(StreamType type) {
-  auto streamInfo = getConstStreamInfo(StreamType2MetadataType(type));
-  if (!streamInfo || !streamInfo->protocol().has_value()) {
-    return "";
-  }
-  return Http::Utility::getProtocolString(streamInfo->protocol().value());
-}
-
-uint32_t Context::getDestinationPort(StreamType type) {
-  auto streamInfo = getConstStreamInfo(StreamType2MetadataType(type));
-  if (!streamInfo)
-    return 0;
-  auto host = streamInfo->upstreamHost();
-  if (!host) {
-    return 0;
-  }
-  auto address = host->address();
-  if (!address) {
-    return 0;
-  }
-  auto ip = address->ip();
-  if (!ip) {
-    return 0;
-  }
-  return ip->port();
-}
-
-uint32_t Context::getResponseCode(StreamType type) {
-  auto streamInfo = getConstStreamInfo(StreamType2MetadataType(type));
-  if (!streamInfo)
-    return 0;
-  return streamInfo->responseCode().value_or(0);
-}
-
-std::string Context::getTlsVersion(StreamType type) {
-  auto streamInfo = getConstStreamInfo(StreamType2MetadataType(type));
-  if (!streamInfo || !streamInfo->downstreamSslConnection()) {
-    return "";
-  }
-  return streamInfo->downstreamSslConnection()->tlsVersion();
-}
-
-absl::optional<bool> Context::peerCertificatePresented(StreamType type) {
-  auto streamInfo = getConstStreamInfo(StreamType2MetadataType(type));
-  if (!streamInfo || !streamInfo->downstreamSslConnection()) {
-    return absl::nullopt;
-  }
-  return streamInfo->downstreamSslConnection()->peerCertificatePresented();
 }
 
 const ProtobufWkt::Struct* Context::getMetadataStructProto(MetadataType type,
                                                            absl::string_view name) {
   switch (type) {
-  case MetadataType::Expression:
-    return nullptr;
   case MetadataType::RequestRoute:
     return getRouteMetadataStructProto(decoder_callbacks_);
   case MetadataType::ResponseRoute:
@@ -1674,7 +1614,7 @@ const ProtobufWkt::Struct* Context::getMetadataStructProto(MetadataType type,
     return nullptr;
   case MetadataType::Cluster: {
     std::string cluster_name;
-    auto stream_info = getConstStreamInfo(type);
+    auto stream_info = getRequestStreamInfo();
     if (!stream_info) {
       return nullptr;
     }
@@ -1691,7 +1631,7 @@ const ProtobufWkt::Struct* Context::getMetadataStructProto(MetadataType type,
     return getStructProtoFromMetadata(host->cluster().metadata(), name);
   }
   default: {
-    auto stream_info = getConstStreamInfo(type);
+    auto stream_info = getRequestStreamInfo();
     if (!stream_info) {
       return nullptr;
     }
@@ -1701,118 +1641,6 @@ const ProtobufWkt::Struct* Context::getMetadataStructProto(MetadataType type,
 }
 
 WasmResult Context::getMetadata(MetadataType type, absl::string_view key, std::string* result_ptr) {
-  if (type == MetadataType::Expression) {
-    static absl::flat_hash_map<std::string, std::function<WasmResult(Context*, std::string*)>>
-        handlers = {
-            {"request.protocol",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto protocol = context->getProtocol(StreamType::Request);
-               *result_ptr = protocol;
-               if (protocol.empty()) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"response.protocol",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto protocol = context->getProtocol(StreamType::Response);
-               *result_ptr = protocol;
-               if (protocol.empty()) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"request.destination_port",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto port = context->getDestinationPort(StreamType::Request);
-               result_ptr->assign(reinterpret_cast<const char*>(&port), sizeof(port));
-               if (!port) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"response.destination_port",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto port = context->getDestinationPort(StreamType::Response);
-               result_ptr->assign(reinterpret_cast<const char*>(&port), sizeof(port));
-               if (!port) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"request.response_code",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto response_code = context->getResponseCode(StreamType::Request);
-               result_ptr->assign(reinterpret_cast<const char*>(&response_code),
-                                  sizeof(response_code));
-               if (!response_code) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"response.response_code",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto response_code = context->getResponseCode(StreamType::Response);
-               result_ptr->assign(reinterpret_cast<const char*>(&response_code),
-                                  sizeof(response_code));
-               if (!response_code) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"request.tls_version",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto tls_version = context->getTlsVersion(StreamType::Request);
-               *result_ptr = tls_version;
-               if (tls_version.empty()) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"response.tls_version",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto tls_version = context->getTlsVersion(StreamType::Response);
-               *result_ptr = tls_version;
-               if (tls_version.empty()) {
-                 return WasmResult::NotFound;
-               }
-               return WasmResult::Ok;
-             }},
-            {"request.peer_certificate_presented",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto peer_certificate_presented =
-                   context->peerCertificatePresented(StreamType::Request);
-               if (!peer_certificate_presented) {
-                 return WasmResult::NotFound;
-               }
-               bool present = peer_certificate_presented.value();
-               result_ptr->assign(reinterpret_cast<const char*>(&present), sizeof(present));
-               return WasmResult::Ok;
-             }},
-            {"response.peer_certificate_presented",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto peer_certificate_presented =
-                   context->peerCertificatePresented(StreamType::Response);
-               if (!peer_certificate_presented) {
-                 return WasmResult::NotFound;
-               }
-               bool present = peer_certificate_presented.value();
-               result_ptr->assign(reinterpret_cast<const char*>(&present), sizeof(present));
-               return WasmResult::Ok;
-             }},
-            {"plugin.direction",
-             [](Context* context, std::string* result_ptr) -> WasmResult {
-               auto direction = context->wasm_->direction_;
-               result_ptr->assign(reinterpret_cast<const char*>(&direction), sizeof(direction));
-               return WasmResult::Ok;
-             }},
-        };
-    auto it = handlers.find(key);
-    if (it == handlers.end()) {
-      return WasmResult::BadExpression;
-    }
-    return it->second(this, result_ptr);
-  }
   auto proto_struct = getMetadataStructProto(type);
   if (!proto_struct) {
     return WasmResult::NotFound;
@@ -1826,18 +1654,6 @@ WasmResult Context::getMetadata(MetadataType type, absl::string_view key, std::s
     return WasmResult::SerializationFailure;
   }
   *result_ptr = std::move(result);
-  return WasmResult::Ok;
-}
-
-WasmResult Context::setMetadata(MetadataType type, absl::string_view key,
-                                absl::string_view serialized_proto_struct) {
-  auto streamInfo = getStreamInfo(type);
-  if (!streamInfo) {
-    return WasmResult::NotFound;
-  }
-  streamInfo->setDynamicMetadata(
-      HttpFilters::HttpFilterNames::get().Wasm,
-      MessageUtil::keyValueStruct(std::string(key), std::string(serialized_proto_struct)));
   return WasmResult::Ok;
 }
 
@@ -1872,18 +1688,19 @@ WasmResult Context::getMetadataStruct(MetadataType type, absl::string_view name,
   return WasmResult::Ok;
 }
 
-WasmResult Context::setMetadataStruct(MetadataType type, absl::string_view name,
-                                      absl::string_view serialized_proto_struct) {
-  auto streamInfo = getStreamInfo(type);
-  if (!streamInfo) {
-    return WasmResult::NotFound;
-  }
-  ProtobufWkt::Struct proto_struct;
-  if (!proto_struct.ParseFromArray(serialized_proto_struct.data(),
-                                   serialized_proto_struct.size())) {
+WasmResult Context::setState(absl::string_view key, absl::string_view serialized_value) {
+  ProtobufWkt::Value value_struct;
+  if (!value_struct.ParseFromArray(serialized_value.data(), serialized_value.size())) {
     return WasmResult::ParseFailure;
   }
-  streamInfo->setDynamicMetadata(std::string(name), proto_struct);
+  if (decoder_callbacks_ == nullptr && encoder_callbacks_ == nullptr) {
+    return WasmResult::NotFound;
+  }
+  StreamInfo::FilterState& filter_state = encoder_callbacks_
+                                              ? encoder_callbacks_->streamInfo().filterState()
+                                              : decoder_callbacks_->streamInfo().filterState();
+  filter_state.setData(key, std::make_unique<WasmState>(value_struct),
+                       StreamInfo::FilterState::StateType::Mutable);
   return WasmResult::Ok;
 }
 
@@ -2182,7 +1999,8 @@ WasmResult Context::getMetric(uint32_t metric_id, uint64_t* result_uint64_ptr) {
 
 Wasm::Wasm(absl::string_view vm, absl::string_view id, absl::string_view vm_configuration,
            Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher,
-           Stats::Scope& scope, PluginDirection direction, const LocalInfo::LocalInfo& local_info,
+           Stats::Scope& scope, envoy::api::v2::core::TrafficDirection direction,
+           const LocalInfo::LocalInfo& local_info,
            const envoy::api::v2::core::Metadata* listener_metadata,
            Stats::ScopeSharedPtr owned_scope)
     : cluster_manager_(cluster_manager), dispatcher_(dispatcher), scope_(scope),
@@ -2262,11 +2080,9 @@ void Wasm::registerCallbacks() {
   _REGISTER_PROXY(log);
 
   _REGISTER_PROXY(getMetadata);
-  _REGISTER_PROXY(setMetadata);
   _REGISTER_PROXY(getMetadataPairs);
-
   _REGISTER_PROXY(getMetadataStruct);
-  _REGISTER_PROXY(setMetadataStruct);
+  _REGISTER_PROXY(setState);
 
   _REGISTER_PROXY(continueRequest);
   _REGISTER_PROXY(continueResponse);
@@ -2799,9 +2615,9 @@ static std::shared_ptr<Wasm> createWasmInternal(
     absl::string_view vm_id, const envoy::config::wasm::v2::VmConfig& vm_config,
     absl::string_view root_id, // e.g. filter instance id
     Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher, Api::Api& api,
-    Stats::Scope& scope, PluginDirection direction, const LocalInfo::LocalInfo& local_info,
-    const envoy::api::v2::core::Metadata* listener_metadata, Stats::ScopeSharedPtr scope_ptr,
-    std::unique_ptr<Context> root_context_for_testing) {
+    Stats::Scope& scope, envoy::api::v2::core::TrafficDirection direction,
+    const LocalInfo::LocalInfo& local_info, const envoy::api::v2::core::Metadata* listener_metadata,
+    Stats::ScopeSharedPtr scope_ptr, std::unique_ptr<Context> root_context_for_testing) {
   auto wasm = std::make_shared<Wasm>(vm_config.vm(), vm_id, vm_config.configuration(),
                                      cluster_manager, dispatcher, scope, direction, local_info,
                                      listener_metadata, scope_ptr);
@@ -2827,7 +2643,8 @@ std::shared_ptr<Wasm> createWasm(absl::string_view vm_id,
                                  absl::string_view root_id, // e.g. filter instance id
                                  Upstream::ClusterManager& cluster_manager,
                                  Event::Dispatcher& dispatcher, Api::Api& api, Stats::Scope& scope,
-                                 PluginDirection direction, const LocalInfo::LocalInfo& local_info,
+                                 envoy::api::v2::core::TrafficDirection direction,
+                                 const LocalInfo::LocalInfo& local_info,
                                  const envoy::api::v2::core::Metadata* listener_metadata,
                                  Stats::ScopeSharedPtr scope_ptr) {
   return createWasmInternal(vm_id, vm_config, root_id, cluster_manager, dispatcher, api, scope,
@@ -2838,9 +2655,9 @@ std::shared_ptr<Wasm> createWasmForTesting(
     absl::string_view vm_id, const envoy::config::wasm::v2::VmConfig& vm_config,
     absl::string_view root_id, // e.g. filter instance id
     Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher, Api::Api& api,
-    Stats::Scope& scope, PluginDirection direction, const LocalInfo::LocalInfo& local_info,
-    const envoy::api::v2::core::Metadata* listener_metadata, Stats::ScopeSharedPtr scope_ptr,
-    std::unique_ptr<Context> root_context_for_testing) {
+    Stats::Scope& scope, envoy::api::v2::core::TrafficDirection direction,
+    const LocalInfo::LocalInfo& local_info, const envoy::api::v2::core::Metadata* listener_metadata,
+    Stats::ScopeSharedPtr scope_ptr, std::unique_ptr<Context> root_context_for_testing) {
   return createWasmInternal(vm_id, vm_config, root_id, cluster_manager, dispatcher, api, scope,
                             direction, local_info, listener_metadata, scope_ptr,
                             std::move(root_context_for_testing));

--- a/source/extensions/common/wasm/well_known_names.h
+++ b/source/extensions/common/wasm/well_known_names.h
@@ -20,6 +20,9 @@ public:
   // Null sandbox: modules must be compiled into envoy and registered name is given in the
   // DataSource.inline_string.
   const std::string Null = "envoy.wasm.vm.null";
+
+  // Filter state name
+  const std::string FilterState = "envoy.wasm";
 };
 
 typedef ConstSingleton<WasmVmValues> WasmVmNames;

--- a/source/extensions/filters/http/wasm/wasm_filter.cc
+++ b/source/extensions/filters/http/wasm/wasm_filter.cc
@@ -25,8 +25,7 @@ FilterConfig::FilterConfig(const envoy::config::filter::http::wasm::v2::Wasm& co
     // individual threads.
     auto base_wasm = Common::Wasm::createWasm(
         vm_id, config.vm_config(), root_id, context.clusterManager(), context.dispatcher(),
-        context.api(), context.scope(),
-        Common::Wasm::pluginDirectionFromTrafficDirection(context.direction()), context.localInfo(),
+        context.api(), context.scope(), context.direction(), context.localInfo(),
         &context.listenerMetadata(), nullptr /* owned_scope */);
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot_->set([base_wasm, root_id, configuration](Event::Dispatcher& dispatcher) {

--- a/source/extensions/wasm/config.cc
+++ b/source/extensions/wasm/config.cc
@@ -23,7 +23,7 @@ Server::WasmSharedPtr WasmFactory::createWasm(const envoy::config::wasm::v2::Was
   auto root_id = config.root_id();
   auto base_wasm = Common::Wasm::createWasm(
       config.vm_id(), config.vm_config(), root_id, context.clusterManager(), context.dispatcher(),
-      context.api(), context.scope(), Common::Wasm::PluginDirection::Unspecified,
+      context.api(), context.scope(), envoy::api::v2::core::TrafficDirection::UNSPECIFIED,
       context.localInfo(), nullptr /* listener_metadata */, context.owned_scope());
   if (config.singleton()) {
     // Return the WASM VM which will be stored as a singleton by the Server.

--- a/test/extensions/filters/http/wasm/test_data/metadata_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/metadata_cpp.cc
@@ -34,7 +34,7 @@ FilterHeadersStatus ExampleContext::onRequestHeaders() {
   if (r != WasmResult::Ok) {
     logDebug(toString(r));
   }
-  r = setMetadataStringValue(MetadataType::Request, "wasm_request_set_key", "wasm_request_set_value");
+  r = setMetadataStringValue("wasm_request_set_key", "wasm_request_set_value");
   if (r != WasmResult::Ok) {
     logDebug(toString(r));
   }

--- a/test/extensions/wasm/wasm_test.cc
+++ b/test/extensions/wasm/wasm_test.cc
@@ -68,7 +68,7 @@ TEST_P(WasmTestMatrix, Logging) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", std::get<0>(GetParam())), "", "", cluster_manager, *dispatcher,
-      *scope, Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      *scope, envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       absl::StrCat("{{ test_rundir }}/test/extensions/wasm/test_data/logging_",
@@ -99,7 +99,7 @@ TEST_P(WasmTest, BadSignature) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/bad_signature_cpp.wasm"));
@@ -120,7 +120,7 @@ TEST(WasmTestWavmOnly, Segv) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       "envoy.wasm.vm.wavm", "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/segv_cpp.wasm"));
@@ -142,7 +142,7 @@ TEST_P(WasmTest, DivByZero) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/segv_cpp.wasm"));
@@ -165,7 +165,7 @@ TEST_P(WasmTest, EmscriptenVersion) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/segv_cpp.wasm"));
@@ -190,7 +190,7 @@ TEST_P(WasmTest, IntrinsicGlobals) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/emscripten_cpp.wasm"));
@@ -217,7 +217,7 @@ TEST_P(WasmTest, Asm2Wasm) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_shared<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/asm2wasm_cpp.wasm"));
@@ -237,7 +237,7 @@ TEST_P(WasmTest, Stats) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/stats_cpp.wasm"));
@@ -265,7 +265,7 @@ TEST_P(WasmTest, StatsHigherLevel) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/stats_cpp.wasm"));
@@ -298,7 +298,7 @@ TEST_P(WasmTest, StatsHighLevel) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   auto wasm = std::make_unique<Extensions::Common::Wasm::Wasm>(
       absl::StrCat("envoy.wasm.vm.", GetParam()), "", "", cluster_manager, *dispatcher, *scope,
-      Common::Wasm::PluginDirection::Unspecified, local_info, nullptr, scope);
+      envoy::api::v2::TrafficDirection::UNSPECIFIED, local_info, nullptr, scope);
   EXPECT_NE(wasm, nullptr);
   const auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/stats_cpp.wasm"));


### PR DESCRIPTION
- use filter state wrapper around a generic value to avoid the implicit proto merge inside `setDynamicMetadata`.
- replace `PluginDirection` with the upstream `TrafficDirection`
- combine metadata selector expression with the get selector handler