### PR TITLE
Add missing Null VM MetadataType using directive.

### DIFF
--- a/source/extensions/common/wasm/null/null_plugin.h
+++ b/source/extensions/common/wasm/null/null_plugin.h
@@ -18,6 +18,7 @@ using FilterTrailersStatus = Http::FilterTrailersStatus;
 using FilterDataStatus = Http::FilterDataStatus;
 using GrpcStatus = Envoy::Grpc::Status::GrpcStatus;
 using MetricType = Envoy::Extensions::Common::Wasm::Context::MetricType;
+using MetadataType = Envoy::Extensions::Common::Wasm::MetadataType;
 using StringView = absl::string_view;
 template <typename T> using Optional = absl::optional<T>;
 } // namespace Plugin


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
