### PR TITLE
add init manager to WasmFactoryContextImpl

### DIFF
--- a/include/envoy/server/wasm_config.h
+++ b/include/envoy/server/wasm_config.h
@@ -3,6 +3,7 @@
 #include "envoy/api/api.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/init/manager.h"
 #include "envoy/server/wasm.h"
 #include "envoy/thread_local/thread_local.h"
 #include "envoy/upstream/cluster_manager.h"
@@ -21,6 +22,11 @@ public:
    * @return Upstream::ClusterManager& singleton for use by the entire server.
    */
   virtual Upstream::ClusterManager& clusterManager() PURE;
+
+  /**
+   * @return Init:Manager& used by synchronizing the WASM initialization.
+   */
+  virtual Init::Manager& initManager() PURE;
 
   /**
    * @return Event::Dispatcher& the main thread's dispatcher. This dispatcher should be used

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -401,8 +401,8 @@ void InstanceImpl::initialize(const Options& options,
           scope = Stats::ScopeSharedPtr(stats_store_.createScope(config.stat_prefix()));
         }
         Configuration::WasmFactoryContextImpl wasm_factory_context(
-            clusterManager(), *dispatcher_, thread_local_, api(), stats_store_, scope,
-            *local_info_);
+            clusterManager(), initManager(), *dispatcher_, thread_local_, api(), stats_store_,
+            scope, *local_info_);
         auto wasm = factory->createWasm(config, wasm_factory_context);
         if (wasm) {
           // If not nullptr, this is a singleton WASM service.

--- a/source/server/wasm_config_impl.h
+++ b/source/server/wasm_config_impl.h
@@ -9,13 +9,15 @@ namespace Configuration {
 
 class WasmFactoryContextImpl : public WasmFactoryContext {
 public:
-  WasmFactoryContextImpl(Upstream::ClusterManager& cluster_manager, Event::Dispatcher& dispatcher,
-                         ThreadLocal::SlotAllocator& tls, Api::Api& api, Stats::Scope& scope,
-                         Stats::ScopeSharedPtr owned_scope, const LocalInfo::LocalInfo& local_info)
-      : cluster_manager_(cluster_manager), dispatcher_(dispatcher), tls_(tls), api_(api),
-        scope_(scope), owned_scope_(owned_scope), local_info_(local_info) {}
+  WasmFactoryContextImpl(Upstream::ClusterManager& cluster_manager, Init::Manager& init_manager,
+                         Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator& tls,
+                         Api::Api& api, Stats::Scope& scope, Stats::ScopeSharedPtr owned_scope,
+                         const LocalInfo::LocalInfo& local_info)
+      : cluster_manager_(cluster_manager), init_manager_(init_manager), dispatcher_(dispatcher),
+        tls_(tls), api_(api), scope_(scope), owned_scope_(owned_scope), local_info_(local_info) {}
 
   Upstream::ClusterManager& clusterManager() override { return cluster_manager_; }
+  Init::Manager& initManager() override { return init_manager_; }
   Event::Dispatcher& dispatcher() override { return dispatcher_; }
   ThreadLocal::SlotAllocator& threadLocal() override { return tls_; }
   Api::Api& api() override { return api_; }
@@ -25,6 +27,7 @@ public:
 
 private:
   Upstream::ClusterManager& cluster_manager_;
+  Init::Manager& init_manager_;
   Event::Dispatcher& dispatcher_;
   ThreadLocal::SlotAllocator& tls_;
   Api::Api& api_;

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -121,8 +121,8 @@ TEST_P(WasmFactoryTest, UnspecifiedRuntime) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher, tls, *api,
-                                                        *scope, scope, local_info);
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
+                                                        tls, *api, *scope, scope, local_info);
 #if defined(ENVOY_WASM_V8) == defined(ENVOY_WASM_WAVM)
   EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context),
                             Extensions::Common::Wasm::WasmException,
@@ -150,8 +150,8 @@ TEST_P(WasmFactoryTest, UnknownRuntime) {
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher, tls, *api,
-                                                        *scope, scope, local_info);
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
+                                                        tls, *api, *scope, scope, local_info);
   EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context),
                             Extensions::Common::Wasm::WasmException,
                             "Failed to create WASM VM using envoy.wasm.vm.invalid runtime. "

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -46,14 +46,15 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASM) {
       "{{ test_rundir }}/test/extensions/wasm/test_data/logging_cpp.wasm"));
   config.set_singleton(true);
   Upstream::MockClusterManager cluster_manager;
+  Init::MockManager init_manager;
   Event::MockDispatcher dispatcher;
   ThreadLocal::MockInstance tls;
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, dispatcher, tls, *api,
-                                                        *scope, scope, local_info);
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
+                                                        tls, *api, *scope, scope, local_info);
   auto wasm = factory->createWasm(config, context);
   EXPECT_NE(wasm, nullptr);
 }
@@ -67,14 +68,15 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASMPerThread) {
   config.mutable_vm_config()->mutable_code()->set_filename(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/wasm/test_data/logging_cpp.wasm"));
   Upstream::MockClusterManager cluster_manager;
+  Init::MockManager init_manager;
   Event::MockDispatcher dispatcher;
   testing::NiceMock<ThreadLocal::MockInstance> tls;
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, dispatcher, tls, *api,
-                                                        *scope, scope, local_info);
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
+                                                        tls, *api, *scope, scope, local_info);
   auto wasm = factory->createWasm(config, context);
   EXPECT_EQ(wasm, nullptr);
 }
@@ -89,14 +91,15 @@ TEST_P(WasmFactoryTest, MissingImport) {
       "{{ test_rundir }}/test/extensions/wasm/test_data/missing_cpp.wasm"));
   config.set_singleton(true);
   Upstream::MockClusterManager cluster_manager;
+  Init::MockManager init_manager;
   Event::MockDispatcher dispatcher;
   ThreadLocal::MockInstance tls;
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, dispatcher, tls, *api,
-                                                        *scope, scope, local_info);
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
+                                                        tls, *api, *scope, scope, local_info);
   EXPECT_THROW_WITH_REGEX(factory->createWasm(config, context),
                           Extensions::Common::Wasm::WasmException,
                           "Failed to load WASM module due to a missing import: env._missing.*");

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -114,13 +114,14 @@ TEST_P(WasmFactoryTest, UnspecifiedRuntime) {
       "{{ test_rundir }}/test/extensions/wasm/test_data/logging_cpp.wasm"));
   config.set_singleton(true);
   Upstream::MockClusterManager cluster_manager;
+  Init::MockManager init_manager;
   Event::MockDispatcher dispatcher;
   ThreadLocal::MockInstance tls;
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, dispatcher, tls, *api,
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher, tls, *api,
                                                         *scope, scope, local_info);
 #if defined(ENVOY_WASM_V8) == defined(ENVOY_WASM_WAVM)
   EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context),
@@ -142,13 +143,14 @@ TEST_P(WasmFactoryTest, UnknownRuntime) {
       "{{ test_rundir }}/test/extensions/wasm/test_data/logging_cpp.wasm"));
   config.set_singleton(true);
   Upstream::MockClusterManager cluster_manager;
+  Init::MockManager init_manager;
   Event::MockDispatcher dispatcher;
   ThreadLocal::MockInstance tls;
   Stats::IsolatedStoreImpl stats_store;
   NiceMock<LocalInfo::MockLocalInfo> local_info;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
-  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, dispatcher, tls, *api,
+  Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher, tls, *api,
                                                         *scope, scope, local_info);
   EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context),
                             Extensions::Common::Wasm::WasmException,


### PR DESCRIPTION
Description: Add init manager to `WasmFactoryContextImpl` used by synchronizing fetching code from remote data source.
Risk Level: Low
Testing: Unit Test
Docs Changes: N/A
Release Notes: N/A
Fixes #Issue: Part of https://github.com/envoyproxy/envoy-wasm/issues/187
[Optional Deprecated:]
