### PR TITLE
Cherry-pick fixes for CVE-2019-15226 and CVE-2019-15225  from envoyproxy/envoy

### DIFF
--- a/api/envoy/api/v2/cds.proto
+++ b/api/envoy/api/v2/cds.proto
@@ -592,8 +592,8 @@ message Cluster {
   //   verification.
   auth.UpstreamTlsContext tls_context = 11;
 
-  // Additional options when handling HTTP requests. These options will be applicable to both
-  // HTTP1 and HTTP2 requests.
+  // Additional options when handling HTTP requests upstream. These options will be applicable to
+  // both HTTP1 and HTTP2 requests.
   core.HttpProtocolOptions common_http_protocol_options = 29;
 
   // Additional options when handling HTTP1 requests.

--- a/api/envoy/api/v2/core/protocol.proto
+++ b/api/envoy/api/v2/core/protocol.proto
@@ -18,11 +18,19 @@ message TcpProtocolOptions {
 }
 
 message HttpProtocolOptions {
-  // The idle timeout for upstream connection pool connections. The idle timeout is defined as the
+  // The idle timeout for connections. The idle timeout is defined as the
   // period in which there are no active requests. If not set, there is no idle timeout. When the
-  // idle timeout is reached the connection will be closed. Note that request based timeouts mean
-  // that HTTP/2 PINGs will not keep the connection alive.
+  // idle timeout is reached the connection will be closed. If the connection is an HTTP/2
+  // downstream connection a drain sequence will occur prior to closing the connection, see
+  // :ref:`drain_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`.
+  // Note that request based timeouts mean that HTTP/2 PINGs will not keep the connection alive.
   google.protobuf.Duration idle_timeout = 1;
+
+  // The maximum number of headers. If unconfigured, the default
+  // maximum number of request headers allowed is 100. Requests that exceed this limit will receive
+  // a 431 response for HTTP/1.x and cause a stream reset for HTTP/2.
+  google.protobuf.UInt32Value max_headers_count = 2 [(validate.rules).uint32 = {gte: 1}];
 }
 
 message Http1ProtocolOptions {

--- a/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
+++ b/api/envoy/config/filter/network/http_connection_manager/v2/http_connection_manager.proto
@@ -23,7 +23,7 @@ import "validate/validate.proto";
 // [#protodoc-title: HTTP connection manager]
 // HTTP connection manager :ref:`configuration overview <config_http_conn_man>`.
 
-// [#comment:next free field: 35]
+// [#comment:next free field: 36]
 message HttpConnectionManager {
   enum CodecType {
     // For every new connection, the connection manager will determine which
@@ -239,6 +239,10 @@ message HttpConnectionManager {
   // <envoy_api_msg_config.trace.v2.Tracing>`.
   Tracing tracing = 7;
 
+  // Additional settings for HTTP requests handled by the connection manager. These will be
+  // applicable to both HTTP1 and HTTP2 requests.
+  envoy.api.v2.core.HttpProtocolOptions common_http_protocol_options = 35;
+
   // Additional HTTP/1 settings that are passed to the HTTP/1 codec.
   api.v2.core.Http1ProtocolOptions http_protocol_options = 8;
 
@@ -267,10 +271,11 @@ message HttpConnectionManager {
   // idle timeout is defined as the period in which there are no active
   // requests. If not set, there is no idle timeout. When the idle timeout is
   // reached the connection will be closed. If the connection is an HTTP/2
-  // connection a drain sequence will occur prior to closing the connection. See
-  // :ref:`drain_timeout
-  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.drain_timeout>`.
-  google.protobuf.Duration idle_timeout = 11;
+  // connection a drain sequence will occur prior to closing the connection.
+  // This field is deprecated. Use :ref:`idle_timeout
+  // <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
+  // instead.
+  google.protobuf.Duration idle_timeout = 11 [deprecated = true];
 
   // The stream idle timeout for connections managed by the connection manager.
   // If not specified, this defaults to 5 minutes. The default value was selected

--- a/docs/root/intro/deprecated.rst
+++ b/docs/root/intro/deprecated.rst
@@ -40,6 +40,11 @@ Version 1.12.0 (pending)
   :ref:`Listener <envoy_api_msg_Listener>`. The latter takes priority if
   specified.
 
+1.11.2 (October 8, 2019)
+========================
+* Use of :ref:`idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.idle_timeout>` is deprecated. Use :ref:`idle_timeout <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>` instead.
+
+
 Version 1.11.0 (July 11, 2019)
 ==============================
 * The --max-stats and --max-obj-name-len flags no longer has any effect.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -87,6 +87,10 @@ Version history
 1.11.2 (October 8, 2019)
 ========================
 * http: fixed CVE-2019-15226 by adding a cached byte size in HeaderMap.
+* http: added :ref:`max headers count <envoy_api_field_core.HttpProtocolOptions.max_headers_count>` for http connections. The default limit is 100.
+* upstream: runtime feature `envoy.reloadable_features.max_response_headers_count` overrides the default limit for upstream :ref:`max headers count <envoy_api_field_Cluster.common_http_protocol_options>`
+* http: added :ref:`common_http_protocol_options <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
+  Runtime feature `envoy.reloadable_features.max_request_headers_count` overrides the default limit for downstream :ref:`max headers count <envoy_api_field_config.filter.network.http_connection_manager.v2.HttpConnectionManager.common_http_protocol_options>`
 
 1.11.1 (August 13, 2019)
 ========================
@@ -169,9 +173,7 @@ Version history
 * router: added a route name field to each http route in route.Route list
 * router: added several new variables for exposing information about the downstream TLS connection via :ref:`header
   formatters <config_http_conn_man_headers_custom_request_headers>`.
-* router: per try timeouts will no longer start before the downstream request has been received
-  in full by the router. This ensures that the per try timeout does not account for slow
-  downstreams and that will not start before the global timeout.
+* router: per try timeouts will no longer start before the downstream request has been received in full by the router.This ensures that the per try timeout does not account for slow downstreams and that will not start before the global timeout.
 * router: added :ref:`RouteAction's auto_host_rewrite_header <envoy_api_field_route.RouteAction.auto_host_rewrite_header>` to allow upstream host header substitution with some other header's value
 * router: added support for UPSTREAM_REMOTE_ADDRESS :ref:`header formatter
   <config_http_conn_man_headers_custom_request_headers>`.

--- a/docs/root/intro/version_history.rst
+++ b/docs/root/intro/version_history.rst
@@ -84,6 +84,10 @@ Version history
 * upstream: added :ref:`fail_traffic_on_panic <envoy_api_field_Cluster.CommonLbConfig.ZoneAwareLbConfig.fail_traffic_on_panic>` to allow failing all requests to a cluster during panic state.
 * zookeeper: parse responses and emit latency stats.
 
+1.11.2 (October 8, 2019)
+========================
+* http: fixed CVE-2019-15226 by adding a cached byte size in HeaderMap.
+
 1.11.1 (August 13, 2019)
 ========================
 * http: added mitigation of client initiated attacks that result in flooding of the downstream HTTP/2 connections. Those attacks can be logged at the "warning" level when the runtime feature `http.connection_manager.log_flood_exception` is enabled. The runtime setting defaults to disabled to avoid log spam when under attack.

--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -78,6 +78,10 @@ public:
 
   /**
    * Log a completed request.
+   * Prior to logging, call refreshByteSize() on HeaderMaps to ensure that an accurate byte size
+   * count is logged.
+   * TODO(asraa): Remove refreshByteSize() requirement when entries in HeaderMap can no longer be
+   * modified by reference and headerMap holds an accurate internal byte size count.
    * @param request_headers supplies the incoming request headers after filtering.
    * @param response_headers supplies response headers.
    * @param response_trailers supplies response trailers.

--- a/include/envoy/http/codec.h
+++ b/include/envoy/http/codec.h
@@ -15,6 +15,13 @@ namespace Http {
 
 // Legacy default value of 60K is safely under both codec default limits.
 static const uint32_t DEFAULT_MAX_REQUEST_HEADERS_KB = 60;
+// Default maximum number of headers.
+static const uint32_t DEFAULT_MAX_HEADERS_COUNT = 100;
+
+const char MaxRequestHeadersCountOverrideKey[] =
+    "envoy.reloadable_features.max_request_headers_count";
+const char MaxResponseHeadersCountOverrideKey[] =
+    "envoy.reloadable_features.max_response_headers_count";
 
 class Stream;
 

--- a/include/envoy/http/header_map.h
+++ b/include/envoy/http/header_map.h
@@ -457,9 +457,41 @@ public:
   virtual void setReferenceKey(const LowerCaseString& key, const std::string& value) PURE;
 
   /**
+   * HeaderMap contains an internal byte size count, updated as entries are added, removed, or
+   * modified through the HeaderMap interface. However, HeaderEntries can be accessed and modified
+   * by reference so that the HeaderMap can no longer accurately update the internal byte size
+   * count.
+   *
+   * Calling byteSize before a HeaderEntry is accessed will return the internal byte size count. The
+   * value is cleared when a HeaderEntry is accessed, and the value is updated and set again when
+   * refreshByteSize is called.
+   *
+   * To guarantee an accurate byte size count, call refreshByteSize.
+   *
+   * @return uint64_t the approximate size of the header map in bytes if valid.
+   */
+  virtual absl::optional<uint64_t> byteSize() const PURE;
+
+  /**
+   * This returns the sum of the byte sizes of the keys and values in the HeaderMap. This also
+   * updates and sets the byte size count.
+   *
+   * To guarantee an accurate byte size count, use this. If it is known HeaderEntries have not been
+   * manipulated since a call to refreshByteSize, it is safe to use byteSize.
+   *
    * @return uint64_t the approximate size of the header map in bytes.
    */
-  virtual uint64_t byteSize() const PURE;
+  virtual uint64_t refreshByteSize() PURE;
+
+  /**
+   * This returns the sum of the byte sizes of the keys and values in the HeaderMap.
+   *
+   * This iterates over the HeaderMap to calculate size and should only be called directly when the
+   * user wants an explicit recalculation of the byte size.
+   *
+   * @return uint64_t the approximate size of the header map in bytes.
+   */
+  virtual uint64_t byteSizeInternal() const PURE;
 
   /**
    * Get a header by key.

--- a/include/envoy/upstream/upstream.h
+++ b/include/envoy/upstream/upstream.h
@@ -768,6 +768,12 @@ public:
   virtual uint64_t maxRequestsPerConnection() const PURE;
 
   /**
+   * @return uint32_t the maximum number of response headers. The default value is 100. Results in a
+   * reset if the number of headers exceeds this value.
+   */
+  virtual uint32_t maxResponseHeadersCount() const PURE;
+
+  /**
    * @return the human readable name of the cluster.
    */
   virtual const std::string& name() const PURE;

--- a/source/common/http/codec_client.cc
+++ b/source/common/http/codec_client.cc
@@ -141,14 +141,15 @@ CodecClientProd::CodecClientProd(Type type, Network::ClientConnectionPtr&& conne
     : CodecClient(type, std::move(connection), host, dispatcher) {
   switch (type) {
   case Type::HTTP1: {
-    codec_ = std::make_unique<Http1::ClientConnectionImpl>(*connection_,
-                                                           host->cluster().statsScope(), *this);
+    codec_ = std::make_unique<Http1::ClientConnectionImpl>(
+        *connection_, host->cluster().statsScope(), *this,
+        host->cluster().maxResponseHeadersCount());
     break;
   }
   case Type::HTTP2: {
     codec_ = std::make_unique<Http2::ClientConnectionImpl>(
         *connection_, *this, host->cluster().statsScope(), host->cluster().http2Settings(),
-        Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
+        Http::DEFAULT_MAX_REQUEST_HEADERS_KB, host->cluster().maxResponseHeadersCount());
     break;
   }
   }

--- a/source/common/http/conn_manager_config.h
+++ b/source/common/http/conn_manager_config.h
@@ -234,6 +234,11 @@ public:
   virtual uint32_t maxRequestHeadersKb() const PURE;
 
   /**
+   * @return maximum number of request headers the codecs will accept.
+   */
+  virtual uint32_t maxRequestHeadersCount() const PURE;
+
+  /**
    * @return per-stream idle timeout for incoming connection manager connections. Zero indicates a
    *         disabled idle timeout.
    */

--- a/source/common/http/conn_manager_utility.cc
+++ b/source/common/http/conn_manager_utility.cc
@@ -41,13 +41,16 @@ std::string ConnectionManagerUtility::determineNextProtocol(Network::Connection&
 ServerConnectionPtr ConnectionManagerUtility::autoCreateCodec(
     Network::Connection& connection, const Buffer::Instance& data,
     ServerConnectionCallbacks& callbacks, Stats::Scope& scope, const Http1Settings& http1_settings,
-    const Http2Settings& http2_settings, const uint32_t max_request_headers_kb) {
+    const Http2Settings& http2_settings, uint32_t max_request_headers_kb,
+    uint32_t max_request_headers_count) {
   if (determineNextProtocol(connection, data) == Http2::ALPN_STRING) {
     return std::make_unique<Http2::ServerConnectionImpl>(connection, callbacks, scope,
-                                                         http2_settings, max_request_headers_kb);
+                                                         http2_settings, max_request_headers_kb,
+                                                         max_request_headers_count);
   } else {
     return std::make_unique<Http1::ServerConnectionImpl>(connection, scope, callbacks,
-                                                         http1_settings, max_request_headers_kb);
+                                                         http1_settings, max_request_headers_kb,
+                                                         max_request_headers_count);
   }
 }
 

--- a/source/common/http/conn_manager_utility.h
+++ b/source/common/http/conn_manager_utility.h
@@ -37,7 +37,7 @@ public:
   autoCreateCodec(Network::Connection& connection, const Buffer::Instance& data,
                   ServerConnectionCallbacks& callbacks, Stats::Scope& scope,
                   const Http1Settings& http1_settings, const Http2Settings& http2_settings,
-                  const uint32_t max_request_headers_kb);
+                  uint32_t max_request_headers_kb, uint32_t max_request_headers_count);
 
   /**
    * Mutates request headers in various ways. This functionality is broken out because of its

--- a/source/common/http/header_map_impl.h
+++ b/source/common/http/header_map_impl.h
@@ -16,12 +16,21 @@ namespace Http {
 
 /**
  * These are definitions of all of the inline header access functions described inside header_map.h
+ *
+ * When a non-const reference or pointer to a HeaderEntry is returned, the internal byte size count
+ * will be cleared, since HeaderMap will no longer be able to accurately update the size of that
+ * HeaderEntry.
+ * TODO(asraa): Remove functions with a non-const HeaderEntry return value.
  */
 #define DEFINE_INLINE_HEADER_FUNCS(name)                                                           \
 public:                                                                                            \
   const HeaderEntry* name() const override { return inline_headers_.name##_; }                     \
-  HeaderEntry* name() override { return inline_headers_.name##_; }                                 \
+  HeaderEntry* name() override {                                                                   \
+    cached_byte_size_.reset();                                                                     \
+    return inline_headers_.name##_;                                                                \
+  }                                                                                                \
   HeaderEntry& insert##name() override {                                                           \
+    cached_byte_size_.reset();                                                                     \
     return maybeCreateInline(&inline_headers_.name##_, Headers::get().name);                       \
   }                                                                                                \
   void remove##name() override { removeInline(&inline_headers_.name##_); }
@@ -43,7 +52,7 @@ public:
    * @param header the header to append to.
    * @param data to append to the header.
    */
-  static void appendToHeader(HeaderString& header, absl::string_view data);
+  static uint64_t appendToHeader(HeaderString& header, absl::string_view data);
 
   HeaderMapImpl();
   explicit HeaderMapImpl(
@@ -71,7 +80,9 @@ public:
   void addCopy(const LowerCaseString& key, const std::string& value) override;
   void setReference(const LowerCaseString& key, const std::string& value) override;
   void setReferenceKey(const LowerCaseString& key, const std::string& value) override;
-  uint64_t byteSize() const override;
+  absl::optional<uint64_t> byteSize() const override;
+  uint64_t refreshByteSize() override;
+  uint64_t byteSizeInternal() const override;
   const HeaderEntry* get(const LowerCaseString& key) const override;
   HeaderEntry* get(const LowerCaseString& key) override;
   void iterate(ConstIterateCb cb, void* context) const override;
@@ -195,9 +206,15 @@ protected:
   HeaderEntryImpl* getExistingInline(absl::string_view key);
 
   void removeInline(HeaderEntryImpl** entry);
+  void addSize(uint64_t size);
+  void subtractSize(uint64_t size);
 
   AllInlineHeaders inline_headers_;
   HeaderList headers_;
+
+  // When present, this holds the internal byte size of the HeaderMap. The value is removed once an
+  // inline header entry is accessed and updated when refreshByteSize() is called.
+  absl::optional<uint64_t> cached_byte_size_ = 0;
 
   ALL_INLINE_HEADERS(DEFINE_INLINE_HEADER_FUNCS)
 };

--- a/source/common/http/http1/codec_impl.cc
+++ b/source/common/http/http1/codec_impl.cc
@@ -460,8 +460,10 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
   header_parsing_state_ = HeaderParsingState::Value;
   current_header_value_.append(data, length);
 
-  const uint32_t total =
-      current_header_field_.size() + current_header_value_.size() + current_header_map_->byteSize();
+  // Verify that the cached value in byte size exists.
+  ASSERT(current_header_map_->byteSize().has_value());
+  const uint32_t total = current_header_field_.size() + current_header_value_.size() +
+                         current_header_map_->byteSize().value();
   if (total > (max_request_headers_kb_ * 1024)) {
     error_code_ = Http::Code::RequestHeaderFieldsTooLarge;
     sendProtocolError();
@@ -472,6 +474,10 @@ void ConnectionImpl::onHeaderValue(const char* data, size_t length) {
 int ConnectionImpl::onHeadersCompleteBase() {
   ENVOY_CONN_LOG(trace, "headers complete", connection_);
   completeLastHeader();
+  // Validate that the completed HeaderMap's cached byte size exists and is correct.
+  // This assert iterates over the HeaderMap.
+  ASSERT(current_header_map_->byteSize().has_value() &&
+         current_header_map_->byteSize() == current_header_map_->byteSizeInternal());
   if (!(parser_.http_major == 1 && parser_.http_minor == 1)) {
     // This is not necessarily true, but it's good enough since higher layers only care if this is
     // HTTP/1.1 or not.

--- a/source/common/http/http1/codec_impl.h
+++ b/source/common/http/http1/codec_impl.h
@@ -191,7 +191,7 @@ public:
 
 protected:
   ConnectionImpl(Network::Connection& connection, Stats::Scope& stats, http_parser_type type,
-                 uint32_t max_request_headers_kb);
+                 uint32_t max_headers_kb, const uint32_t max_headers_count);
 
   bool resetStreamCalled() { return reset_stream_called_; }
 
@@ -300,7 +300,8 @@ private:
   Buffer::RawSlice reserved_iovec_;
   char* reserved_current_{};
   Protocol protocol_{Protocol::Http11};
-  const uint32_t max_request_headers_kb_;
+  const uint32_t max_headers_kb_;
+  const uint32_t max_headers_count_;
 
   bool strict_header_validation_;
 };
@@ -312,7 +313,7 @@ class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
   ServerConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
                        ServerConnectionCallbacks& callbacks, Http1Settings settings,
-                       uint32_t max_request_headers_kb);
+                       uint32_t max_request_headers_kb, const uint32_t max_request_headers_count);
 
   bool supports_http_10() override { return codec_settings_.accept_http_10_; }
 
@@ -363,7 +364,7 @@ private:
 class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
-                       ConnectionCallbacks& callbacks);
+                       ConnectionCallbacks& callbacks, const uint32_t max_response_headers_count);
 
   // Http::ClientConnection
   StreamEncoder& newStream(StreamDecoder& response_decoder) override;

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -370,10 +370,10 @@ bool checkRuntimeOverride(bool config_value, const char* override_key) {
 } // namespace
 
 ConnectionImpl::ConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
-                               const Http2Settings& http2_settings,
-                               const uint32_t max_request_headers_kb)
+                               const Http2Settings& http2_settings, const uint32_t max_headers_kb,
+                               const uint32_t max_headers_count)
     : stats_{ALL_HTTP2_CODEC_STATS(POOL_COUNTER_PREFIX(stats, "http2."))}, connection_(connection),
-      max_request_headers_kb_(max_request_headers_kb),
+      max_headers_kb_(max_headers_kb), max_headers_count_(max_headers_count),
       per_stream_buffer_limit_(http2_settings.initial_stream_window_size_),
       stream_error_on_invalid_http_messaging_(checkRuntimeOverride(
           http2_settings.stream_error_on_invalid_http_messaging_, InvalidHttpMessagingOverrideKey)),
@@ -819,9 +819,11 @@ int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
     return 0;
   }
   stream->saveHeader(std::move(name), std::move(value));
+
   // Verify that the cached value in byte size exists.
   ASSERT(stream->headers_->byteSize().has_value());
-  if (stream->headers_->byteSize().value() > max_request_headers_kb_ * 1024) {
+  if (stream->headers_->byteSize().value() > max_headers_kb_ * 1024 ||
+      stream->headers_->size() > max_headers_count_) {
     // This will cause the library to reset/close the stream.
     stats_.header_overflow_.inc();
     return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;
@@ -1081,8 +1083,10 @@ ConnectionImpl::ClientHttp2Options::ClientHttp2Options(const Http2Settings& http
 ClientConnectionImpl::ClientConnectionImpl(Network::Connection& connection,
                                            Http::ConnectionCallbacks& callbacks,
                                            Stats::Scope& stats, const Http2Settings& http2_settings,
-                                           const uint32_t max_request_headers_kb)
-    : ConnectionImpl(connection, stats, http2_settings, max_request_headers_kb),
+                                           const uint32_t max_response_headers_kb,
+                                           const uint32_t max_response_headers_count)
+    : ConnectionImpl(connection, stats, http2_settings, max_response_headers_kb,
+                     max_response_headers_count),
       callbacks_(callbacks) {
   ClientHttp2Options client_http2_options(http2_settings);
   nghttp2_session_client_new2(&session_, http2_callbacks_.callbacks(), base(),
@@ -1130,8 +1134,10 @@ int ClientConnectionImpl::onHeader(const nghttp2_frame* frame, HeaderString&& na
 ServerConnectionImpl::ServerConnectionImpl(Network::Connection& connection,
                                            Http::ServerConnectionCallbacks& callbacks,
                                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                                           const uint32_t max_request_headers_kb)
-    : ConnectionImpl(connection, scope, http2_settings, max_request_headers_kb),
+                                           const uint32_t max_request_headers_kb,
+                                           const uint32_t max_request_headers_count)
+    : ConnectionImpl(connection, scope, http2_settings, max_request_headers_kb,
+                     max_request_headers_count),
       callbacks_(callbacks) {
   Http2Options http2_options(http2_settings);
   nghttp2_session_server_new2(&session_, http2_callbacks_.callbacks(), base(),

--- a/source/common/http/http2/codec_impl.cc
+++ b/source/common/http/http2/codec_impl.cc
@@ -509,6 +509,10 @@ int ConnectionImpl::onFrameReceived(const nghttp2_frame* frame) {
 
   switch (frame->hd.type) {
   case NGHTTP2_HEADERS: {
+    // Verify that the final HeaderMap's byte size is under the limit before decoding headers.
+    // This assert iterates over the HeaderMap.
+    ASSERT(stream->headers_->byteSize().has_value() &&
+           stream->headers_->byteSize().value() == stream->headers_->byteSizeInternal());
     stream->remote_end_stream_ = frame->hd.flags & NGHTTP2_FLAG_END_STREAM;
     if (!stream->cookies_.empty()) {
       HeaderString key(Headers::get().Cookie);
@@ -620,6 +624,12 @@ int ConnectionImpl::onFrameSend(const nghttp2_frame* frame) {
   case NGHTTP2_HEADERS:
   case NGHTTP2_DATA: {
     StreamImpl* stream = getStream(frame->hd.stream_id);
+    if (stream->headers_) {
+      // Verify that the final HeaderMap's byte size is under the limit before sending frames.
+      // This assert iterates over the HeaderMap.
+      ASSERT(stream->headers_->byteSize().has_value() &&
+             stream->headers_->byteSize().value() == stream->headers_->byteSizeInternal());
+    }
     stream->local_end_stream_sent_ = frame->hd.flags & NGHTTP2_FLAG_END_STREAM;
     break;
   }
@@ -808,9 +818,10 @@ int ConnectionImpl::saveHeader(const nghttp2_frame* frame, HeaderString&& name,
     stats_.headers_cb_no_stream_.inc();
     return 0;
   }
-
   stream->saveHeader(std::move(name), std::move(value));
-  if (stream->headers_->byteSize() > max_request_headers_kb_ * 1024) {
+  // Verify that the cached value in byte size exists.
+  ASSERT(stream->headers_->byteSize().has_value());
+  if (stream->headers_->byteSize().value() > max_request_headers_kb_ * 1024) {
     // This will cause the library to reset/close the stream.
     stats_.header_overflow_.inc();
     return NGHTTP2_ERR_TEMPORAL_CALLBACK_FAILURE;

--- a/source/common/http/http2/codec_impl.h
+++ b/source/common/http/http2/codec_impl.h
@@ -79,7 +79,8 @@ public:
 class ConnectionImpl : public virtual Connection, protected Logger::Loggable<Logger::Id::http2> {
 public:
   ConnectionImpl(Network::Connection& connection, Stats::Scope& stats,
-                 const Http2Settings& http2_settings, const uint32_t max_request_headers_kb);
+                 const Http2Settings& http2_settings, const uint32_t max_headers_kb,
+                 const uint32_t max_headers_count);
 
   ~ConnectionImpl() override;
 
@@ -288,7 +289,8 @@ protected:
   nghttp2_session* session_{};
   CodecStats stats_;
   Network::Connection& connection_;
-  const uint32_t max_request_headers_kb_;
+  const uint32_t max_headers_kb_;
+  const uint32_t max_headers_count_;
   uint32_t per_stream_buffer_limit_;
   bool allow_metadata_;
   const bool stream_error_on_invalid_http_messaging_;
@@ -394,7 +396,8 @@ class ClientConnectionImpl : public ClientConnection, public ConnectionImpl {
 public:
   ClientConnectionImpl(Network::Connection& connection, ConnectionCallbacks& callbacks,
                        Stats::Scope& stats, const Http2Settings& http2_settings,
-                       const uint32_t max_request_headers_kb);
+                       const uint32_t max_response_headers_kb,
+                       const uint32_t max_response_headers_count);
 
   // Http::ClientConnection
   Http::StreamEncoder& newStream(StreamDecoder& response_decoder) override;
@@ -426,7 +429,8 @@ class ServerConnectionImpl : public ServerConnection, public ConnectionImpl {
 public:
   ServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
                        Stats::Scope& scope, const Http2Settings& http2_settings,
-                       const uint32_t max_request_headers_kb);
+                       const uint32_t max_request_headers_kb,
+                       const uint32_t max_request_headers_count);
 
 private:
   // ConnectionImpl

--- a/source/common/router/router.cc
+++ b/source/common/router/router.cc
@@ -1368,6 +1368,15 @@ Filter::UpstreamRequest::~UpstreamRequest() {
 
   stream_info_.setUpstreamTiming(upstream_timing_);
   stream_info_.onRequestComplete();
+  // Prior to logging, refresh the byte size of the HeaderMaps.
+  // TODO(asraa): Remove this when entries in HeaderMap can no longer be modified by reference and
+  // HeaderMap holds an accurate internal byte size count.
+  if (upstream_headers_ != nullptr) {
+    upstream_headers_->refreshByteSize();
+  }
+  if (upstream_trailers_ != nullptr) {
+    upstream_trailers_->refreshByteSize();
+  }
   for (const auto& upstream_log : parent_.config_.upstream_logs_) {
     upstream_log->log(parent_.downstream_headers_, upstream_headers_.get(),
                       upstream_trailers_.get(), stream_info_);

--- a/source/common/upstream/BUILD
+++ b/source/common/upstream/BUILD
@@ -389,6 +389,7 @@ envoy_cc_library(
         "//source/common/network:utility_lib",
         "//source/common/protobuf",
         "//source/common/protobuf:utility_lib",
+        "//source/common/runtime:runtime_lib",
         "//source/extensions/transport_sockets:well_known_names",
         "//source/server:transport_socket_config_lib",
         "@envoy_api//envoy/api/v2/core:base_cc",

--- a/source/common/upstream/upstream_impl.cc
+++ b/source/common/upstream/upstream_impl.cc
@@ -30,6 +30,7 @@
 #include "common/network/socket_option_factory.h"
 #include "common/protobuf/protobuf.h"
 #include "common/protobuf/utility.h"
+#include "common/runtime/runtime_impl.h"
 #include "common/upstream/eds.h"
 #include "common/upstream/health_checker_impl.h"
 #include "common/upstream/logical_dns_cluster.h"
@@ -593,6 +594,10 @@ ClusterInfoImpl::ClusterInfoImpl(
     : runtime_(runtime), name_(config.name()), type_(config.type()),
       max_requests_per_connection_(
           PROTOBUF_GET_WRAPPED_OR_DEFAULT(config, max_requests_per_connection, 0)),
+      max_response_headers_count_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          config.common_http_protocol_options(), max_headers_count,
+          runtime_.snapshot().getInteger(Http::MaxResponseHeadersCountOverrideKey,
+                                         Http::DEFAULT_MAX_HEADERS_COUNT))),
       connect_timeout_(
           std::chrono::milliseconds(PROTOBUF_GET_MS_REQUIRED(config, connect_timeout))),
       per_connection_buffer_limit_bytes_(
@@ -686,6 +691,7 @@ ClusterInfoImpl::ClusterInfoImpl(
     idle_timeout_ = std::chrono::milliseconds(
         DurationUtil::durationToMilliseconds(config.common_http_protocol_options().idle_timeout()));
   }
+
   if (config.has_eds_cluster_config()) {
     if (config.type() != envoy::api::v2::Cluster::EDS) {
       throw EnvoyException("eds_cluster_config set in a non-EDS cluster");

--- a/source/common/upstream/upstream_impl.h
+++ b/source/common/upstream/upstream_impl.h
@@ -558,6 +558,7 @@ public:
   }
   bool maintenanceMode() const override;
   uint64_t maxRequestsPerConnection() const override { return max_requests_per_connection_; }
+  uint32_t maxResponseHeadersCount() const override { return max_response_headers_count_; }
   const std::string& name() const override { return name_; }
   ResourceManager& resourceManager(ResourcePriority priority) const override;
   Network::TransportSocketFactory& transportSocketFactory() const override {
@@ -601,6 +602,7 @@ private:
   const std::string name_;
   const envoy::api::v2::Cluster::DiscoveryType type_;
   const uint64_t max_requests_per_connection_;
+  const uint32_t max_response_headers_count_;
   const std::chrono::milliseconds connect_timeout_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   const uint32_t per_connection_buffer_limit_bytes_;

--- a/source/extensions/access_loggers/common/access_log_base.h
+++ b/source/extensions/access_loggers/common/access_log_base.h
@@ -27,6 +27,11 @@ public:
 
   /**
    * Log a completed request if the underlying AccessLog `filter_` allows it.
+   *
+   * Prior to logging, call refreshByteSize() on HeaderMaps to ensure that an accurate byte size
+   * count is logged.
+   * TODO(asraa): Remove refreshByteSize() requirement when entries in HeaderMap can no longer be
+   * modified by reference and HeaderMap holds an accurate internal byte size count.
    */
   void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
            const Http::HeaderMap* response_trailers,

--- a/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
+++ b/source/extensions/access_loggers/grpc/http_grpc_access_log_impl.cc
@@ -95,7 +95,7 @@ void HttpGrpcAccessLog::emitLog(const Http::HeaderMap& request_headers,
     request_properties->set_original_path(
         std::string(request_headers.EnvoyOriginalPath()->value().getStringView()));
   }
-  request_properties->set_request_headers_bytes(request_headers.byteSize());
+  request_properties->set_request_headers_bytes(request_headers.byteSize().value());
   request_properties->set_request_body_bytes(stream_info.bytesReceived());
   if (request_headers.Method() != nullptr) {
     envoy::api::v2::core::RequestMethod method =
@@ -123,7 +123,7 @@ void HttpGrpcAccessLog::emitLog(const Http::HeaderMap& request_headers,
   if (stream_info.responseCodeDetails()) {
     response_properties->set_response_code_details(stream_info.responseCodeDetails().value());
   }
-  response_properties->set_response_headers_bytes(response_headers.byteSize());
+  response_properties->set_response_headers_bytes(response_headers.byteSize().value());
   response_properties->set_response_body_bytes(stream_info.bytesSent());
   if (!response_headers_to_log_.empty()) {
     auto* logged_headers = response_properties->mutable_response_headers();

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -79,7 +79,7 @@ absl::optional<CelValue> RequestWrapper::operator[](CelValue key) const {
     } else if (value == UserAgent) {
       return convertHeaderEntry(headers_.value_->UserAgent());
     } else if (value == TotalSize) {
-      return CelValue::CreateInt64(info_.bytesReceived() + headers_.value_->byteSize());
+      return CelValue::CreateInt64(info_.bytesReceived() + headers_.value_->byteSize().value());
     }
   }
   return {};

--- a/source/extensions/filters/http/rbac/rbac_filter.cc
+++ b/source/extensions/filters/http/rbac/rbac_filter.cc
@@ -76,6 +76,10 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
   if (shadow_engine != nullptr) {
     std::string shadow_resp_code =
         Filters::Common::RBAC::DynamicMetadataKeysSingleton::get().EngineResultAllowed;
+    // Refresh headers byte size before checking if allowed.
+    // TODO(asraa): Remove this when entries in HeaderMap can no longer be modified by reference and
+    // HeaderMap holds an accurate internal byte size count.
+    headers.refreshByteSize();
     if (shadow_engine->allowed(*callbacks_->connection(), headers, callbacks_->streamInfo(),
                                &effective_policy_id)) {
       ENVOY_LOG(debug, "shadow allowed");
@@ -105,6 +109,10 @@ Http::FilterHeadersStatus RoleBasedAccessControlFilter::decodeHeaders(Http::Head
   const auto engine =
       config_->engine(callbacks_->route(), Filters::Common::RBAC::EnforcementMode::Enforced);
   if (engine != nullptr) {
+    // Refresh headers byte size before checking if allowed.
+    // TODO(asraa): Remove this when entries in HeaderMap can no longer be modified by reference and
+    // HeaderMap holds an accurate internal byte size count.
+    headers.refreshByteSize();
     if (engine->allowed(*callbacks_->connection(), headers, callbacks_->streamInfo(), nullptr)) {
       ENVOY_LOG(debug, "enforced allowed");
       config_->stats().allowed_.inc();

--- a/source/extensions/filters/network/http_connection_manager/BUILD
+++ b/source/extensions/filters/network/http_connection_manager/BUILD
@@ -38,6 +38,7 @@ envoy_cc_library(
         "//source/common/protobuf:utility_lib",
         "//source/common/router:rds_lib",
         "//source/common/router:scoped_rds_lib",
+        "//source/common/runtime:runtime_lib",
         "//source/extensions/filters/network:well_known_names",
         "//source/extensions/filters/network/common:factory_base_lib",
         "@envoy_api//envoy/config/filter/network/http_connection_manager/v2:http_connection_manager_cc",

--- a/source/extensions/filters/network/http_connection_manager/config.cc
+++ b/source/extensions/filters/network/http_connection_manager/config.cc
@@ -24,6 +24,7 @@
 #include "common/protobuf/utility.h"
 #include "common/router/rds_impl.h"
 #include "common/router/scoped_rds.h"
+#include "common/runtime/runtime_impl.h"
 
 namespace Envoy {
 namespace Extensions {
@@ -153,7 +154,11 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
       http1_settings_(Http::Utility::parseHttp1Settings(config.http_protocol_options())),
       max_request_headers_kb_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
           config, max_request_headers_kb, Http::DEFAULT_MAX_REQUEST_HEADERS_KB)),
-      idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config, idle_timeout)),
+      max_request_headers_count_(PROTOBUF_GET_WRAPPED_OR_DEFAULT(
+          config.common_http_protocol_options(), max_headers_count,
+          context.runtime().snapshot().getInteger(Http::MaxRequestHeadersCountOverrideKey,
+                                                  Http::DEFAULT_MAX_HEADERS_COUNT))),
+      idle_timeout_(PROTOBUF_GET_OPTIONAL_MS(config.common_http_protocol_options(), idle_timeout)),
       stream_idle_timeout_(
           PROTOBUF_GET_MS_OR_DEFAULT(config, stream_idle_timeout, StreamIdleTimeoutMs)),
       request_timeout_(PROTOBUF_GET_MS_OR_DEFAULT(config, request_timeout, RequestTimeoutMs)),
@@ -176,6 +181,13 @@ HttpConnectionManagerConfig::HttpConnectionManagerConfig(
 #endif
                                                       ))),
       merge_slashes_(config.merge_slashes()) {
+  // If idle_timeout_ was not configured in common_http_protocol_options, use value in deprecated
+  // idle_timeout field.
+  // TODO(asraa): Remove when idle_timeout is removed.
+  if (!idle_timeout_) {
+    idle_timeout_ = PROTOBUF_GET_OPTIONAL_MS(config, idle_timeout);
+  }
+
   // If scoped RDS is enabled, avoid creating a route config provider. Route config providers will
   // be managed by the scoped routing logic instead.
   switch (config.route_specifier_case()) {
@@ -400,14 +412,16 @@ HttpConnectionManagerConfig::createCodec(Network::Connection& connection,
   switch (codec_type_) {
   case CodecType::HTTP1:
     return std::make_unique<Http::Http1::ServerConnectionImpl>(
-        connection, context_.scope(), callbacks, http1_settings_, maxRequestHeadersKb());
+        connection, context_.scope(), callbacks, http1_settings_, maxRequestHeadersKb(),
+        maxRequestHeadersCount());
   case CodecType::HTTP2:
     return std::make_unique<Http::Http2::ServerConnectionImpl>(
-        connection, callbacks, context_.scope(), http2_settings_, maxRequestHeadersKb());
+        connection, callbacks, context_.scope(), http2_settings_, maxRequestHeadersKb(),
+        maxRequestHeadersCount());
   case CodecType::AUTO:
-    return Http::ConnectionManagerUtility::autoCreateCodec(connection, data, callbacks,
-                                                           context_.scope(), http1_settings_,
-                                                           http2_settings_, maxRequestHeadersKb());
+    return Http::ConnectionManagerUtility::autoCreateCodec(
+        connection, data, callbacks, context_.scope(), http1_settings_, http2_settings_,
+        maxRequestHeadersKb(), maxRequestHeadersCount());
   }
 
   NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/filters/network/http_connection_manager/config.h
+++ b/source/extensions/filters/network/http_connection_manager/config.h
@@ -106,6 +106,7 @@ public:
   bool generateRequestId() override { return generate_request_id_; }
   bool preserveExternalRequestId() const override { return preserve_external_request_id_; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -175,6 +176,7 @@ private:
   Http::TracingConnectionManagerConfigPtr tracing_config_;
   absl::optional<std::string> user_agent_;
   const uint32_t max_request_headers_kb_;
+  const uint32_t max_request_headers_count_;
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_;
   std::chrono::milliseconds request_timeout_;

--- a/source/server/http/admin.cc
+++ b/source/server/http/admin.cc
@@ -1235,7 +1235,7 @@ Http::ServerConnectionPtr AdminImpl::createCodec(Network::Connection& connection
                                                  Http::ServerConnectionCallbacks& callbacks) {
   return Http::ConnectionManagerUtility::autoCreateCodec(
       connection, data, callbacks, server_.stats(), Http::Http1Settings(), Http::Http2Settings(),
-      maxRequestHeadersKb());
+      maxRequestHeadersKb(), maxRequestHeadersCount());
 }
 
 bool AdminImpl::createNetworkFilterChain(Network::Connection& connection,

--- a/source/server/http/admin.h
+++ b/source/server/http/admin.h
@@ -113,6 +113,7 @@ public:
   bool preserveExternalRequestId() const override { return false; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return {}; }
   std::chrono::milliseconds requestTimeout() const override { return {}; }
   std::chrono::milliseconds delayedCloseTimeout() const override { return {}; }
@@ -366,6 +367,7 @@ private:
   NullScopedRouteConfigProvider scoped_route_config_provider_;
   std::list<UrlHandler> handlers_;
   const uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
+  const uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   absl::optional<std::string> user_agent_;
   Http::SlowDateProviderImpl date_provider_;

--- a/test/common/http/conn_manager_impl_fuzz_test.cc
+++ b/test/common/http/conn_manager_impl_fuzz_test.cc
@@ -84,6 +84,7 @@ public:
   bool generateRequestId() override { return true; }
   bool preserveExternalRequestId() const override { return false; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -145,6 +146,7 @@ public:
   ConnectionManagerTracingStats tracing_stats_;
   ConnectionManagerListenerStats listener_stats_;
   uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
+  uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_{};
   std::chrono::milliseconds request_timeout_{};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -268,6 +268,7 @@ public:
   bool generateRequestId() override { return true; }
   bool preserveExternalRequestId() const override { return false; }
   uint32_t maxRequestHeadersKb() const override { return max_request_headers_kb_; }
+  uint32_t maxRequestHeadersCount() const override { return max_request_headers_count_; }
   absl::optional<std::chrono::milliseconds> idleTimeout() const override { return idle_timeout_; }
   std::chrono::milliseconds streamIdleTimeout() const override { return stream_idle_timeout_; }
   std::chrono::milliseconds requestTimeout() const override { return request_timeout_; }
@@ -339,6 +340,7 @@ public:
   std::vector<Http::ClientCertDetailsType> set_current_client_cert_details_;
   absl::optional<std::string> user_agent_;
   uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
+  uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   absl::optional<std::chrono::milliseconds> idle_timeout_;
   std::chrono::milliseconds stream_idle_timeout_{};
   std::chrono::milliseconds request_timeout_{};

--- a/test/common/http/conn_manager_impl_test.cc
+++ b/test/common/http/conn_manager_impl_test.cc
@@ -4409,51 +4409,6 @@ TEST_F(HttpConnectionManagerImplTest, DisableKeepAliveWhenOverloaded) {
   EXPECT_EQ(1U, stats_.named_.downstream_cx_overload_disable_keepalive_.value());
 }
 
-TEST_F(HttpConnectionManagerImplTest, OverlyLongHeadersRejected) {
-  setup(false, "");
-
-  std::string response_code;
-  std::string response_body;
-  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
-    StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
-    HeaderMapPtr headers{
-        new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
-    headers->addCopy(LowerCaseString("Foo"), std::string(60 * 1024, 'a'));
-
-    EXPECT_CALL(response_encoder_, encodeHeaders(_, true))
-        .WillOnce(Invoke([&response_code](const HeaderMap& headers, bool) -> void {
-          response_code = std::string(headers.Status()->value().getStringView());
-        }));
-    decoder->decodeHeaders(std::move(headers), true);
-    conn_manager_->newStream(response_encoder_);
-  }));
-
-  Buffer::OwnedImpl fake_input("1234");
-  conn_manager_->onData(fake_input, false); // kick off request
-
-  EXPECT_EQ("431", response_code);
-  EXPECT_EQ("", response_body);
-}
-
-TEST_F(HttpConnectionManagerImplTest, OverlyLongHeadersAcceptedIfConfigured) {
-  max_request_headers_kb_ = 62;
-  setup(false, "");
-
-  EXPECT_CALL(*codec_, dispatch(_)).WillOnce(Invoke([&](Buffer::Instance&) -> void {
-    StreamDecoder* decoder = &conn_manager_->newStream(response_encoder_);
-    HeaderMapPtr headers{
-        new TestHeaderMapImpl{{":authority", "host"}, {":path", "/"}, {":method", "GET"}}};
-    headers->addCopy(LowerCaseString("Foo"), std::string(60 * 1024, 'a'));
-
-    EXPECT_CALL(response_encoder_, encodeHeaders(_, _)).Times(0);
-    decoder->decodeHeaders(std::move(headers), true);
-    conn_manager_->newStream(response_encoder_);
-  }));
-
-  Buffer::OwnedImpl fake_input("1234");
-  conn_manager_->onData(fake_input, false); // kick off request
-}
-
 TEST_F(HttpConnectionManagerImplTest, TestStopAllIterationAndBufferOnDecodingPathFirstFilter) {
   setup(false, "envoy-custom-server", false);
   setUpEncoderAndDecoder(true, true);

--- a/test/common/http/conn_manager_utility_test.cc
+++ b/test/common/http/conn_manager_utility_test.cc
@@ -56,6 +56,7 @@ public:
   MOCK_METHOD0(generateRequestId, bool());
   MOCK_CONST_METHOD0(preserveExternalRequestId, bool());
   MOCK_CONST_METHOD0(maxRequestHeadersKb, uint32_t());
+  MOCK_CONST_METHOD0(maxRequestHeadersCount, uint32_t());
   MOCK_CONST_METHOD0(idleTimeout, absl::optional<std::chrono::milliseconds>());
   MOCK_CONST_METHOD0(streamIdleTimeout, std::chrono::milliseconds());
   MOCK_CONST_METHOD0(requestTimeout, std::chrono::milliseconds());

--- a/test/common/http/header_map_impl_speed_test.cc
+++ b/test/common/http/header_map_impl_speed_test.cc
@@ -104,7 +104,7 @@ static void HeaderMapImplGetByteSize(benchmark::State& state) {
   addDummyHeaders(headers, state.range(0));
   uint64_t size = 0;
   for (auto _ : state) {
-    size += headers.byteSize();
+    size += headers.byteSize().value();
   }
   benchmark::DoNotOptimize(size);
 }

--- a/test/common/http/http2/codec_impl_test.cc
+++ b/test/common/http/http2/codec_impl_test.cc
@@ -1089,17 +1089,19 @@ TEST_P(Http2CodecImplTest, TestLargeRequestHeadersAtLimitAccepted) {
 
   TestHeaderMapImpl request_headers;
   HttpTestUtility::addDefaultHeaders(request_headers);
+  // Refresh byte size after adding default inline headers by reference.
+  request_headers.refreshByteSize();
   std::string key = "big";
   uint32_t head_room = 77;
   uint32_t long_string_length =
-      codec_limit_kb * 1024 - request_headers.byteSize() - key.length() - head_room;
+      codec_limit_kb * 1024 - request_headers.byteSize().value() - key.length() - head_room;
   std::string long_string = std::string(long_string_length, 'q');
   request_headers.addCopy(key, long_string);
 
   // The amount of data sent to the codec is not equivalent to the size of the
   // request headers that Envoy computes, as the codec limits based on the
   // entire http2 frame. The exact head room needed (76) was found through iteration.
-  ASSERT_EQ(request_headers.byteSize() + head_room, codec_limit_kb * 1024);
+  ASSERT_EQ(request_headers.byteSize().value() + head_room, codec_limit_kb * 1024);
 
   EXPECT_CALL(request_decoder_, decodeHeaders_(_, _));
   request_encoder_->encodeHeaders(request_headers, true);

--- a/test/common/http/http2/codec_impl_test_util.h
+++ b/test/common/http/http2/codec_impl_test_util.h
@@ -10,9 +10,9 @@ class TestServerConnectionImpl : public ServerConnectionImpl {
 public:
   TestServerConnectionImpl(Network::Connection& connection, ServerConnectionCallbacks& callbacks,
                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                           uint32_t max_request_headers_kb)
-      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {
-  }
+                           uint32_t max_request_headers_kb, uint32_t max_request_headers_count)
+      : ServerConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb,
+                             max_request_headers_count) {}
   nghttp2_session* session() { return session_; }
   using ServerConnectionImpl::getStream;
 };
@@ -21,9 +21,9 @@ class TestClientConnectionImpl : public ClientConnectionImpl {
 public:
   TestClientConnectionImpl(Network::Connection& connection, Http::ConnectionCallbacks& callbacks,
                            Stats::Scope& scope, const Http2Settings& http2_settings,
-                           uint32_t max_request_headers_kb)
-      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb) {
-  }
+                           uint32_t max_request_headers_kb, uint32_t max_request_headers_count)
+      : ClientConnectionImpl(connection, callbacks, scope, http2_settings, max_request_headers_kb,
+                             max_request_headers_count) {}
   nghttp2_session* session() { return session_; }
   using ClientConnectionImpl::getStream;
   using ConnectionImpl::sendPendingFrames;

--- a/test/common/http/http2/frame_replay.cc
+++ b/test/common/http/http2/frame_replay.cc
@@ -67,9 +67,9 @@ CodecFrameInjector::CodecFrameInjector(const std::string& injector_name)
 }
 
 ClientCodecFrameInjector::ClientCodecFrameInjector() : CodecFrameInjector("server") {
-  auto client = std::make_unique<TestClientConnectionImpl>(client_connection_, client_callbacks_,
-                                                           stats_store_, settings_,
-                                                           Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
+  auto client = std::make_unique<TestClientConnectionImpl>(
+      client_connection_, client_callbacks_, stats_store_, settings_,
+      Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT);
   request_encoder_ = &client->newStream(response_decoder_);
   connection_ = std::move(client);
   ON_CALL(client_connection_, write(_, _))
@@ -87,9 +87,9 @@ ClientCodecFrameInjector::ClientCodecFrameInjector() : CodecFrameInjector("serve
 }
 
 ServerCodecFrameInjector::ServerCodecFrameInjector() : CodecFrameInjector("client") {
-  connection_ = std::make_unique<TestServerConnectionImpl>(server_connection_, server_callbacks_,
-                                                           stats_store_, settings_,
-                                                           Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
+  connection_ = std::make_unique<TestServerConnectionImpl>(
+      server_connection_, server_callbacks_, stats_store_, settings_,
+      Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT);
   EXPECT_CALL(server_callbacks_, newStream(_, _))
       .WillRepeatedly(Invoke([&](StreamEncoder& encoder, bool) -> StreamDecoder& {
         encoder.getStream().addCallbacks(server_stream_callbacks_);

--- a/test/extensions/filters/network/http_connection_manager/config_test.cc
+++ b/test/extensions/filters/network/http_connection_manager/config_test.cc
@@ -483,6 +483,75 @@ TEST_F(HttpConnectionManagerConfigTest, DisabledStreamIdleTimeout) {
   EXPECT_EQ(0, config.streamIdleTimeout().count());
 }
 
+// Validate that deprecated idle_timeout is still ingested.
+TEST_F(HttpConnectionManagerConfigTest, DeprecatedIdleTimeout) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  idle_timeout: 1s
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_);
+  EXPECT_EQ(1000, config.idleTimeout().value().count());
+}
+
+// Validate that idle_timeout set in common_http_protocol_options is used.
+TEST_F(HttpConnectionManagerConfigTest, CommonHttpProtocolIdleTimeout) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  common_http_protocol_options:
+    idle_timeout: 1s
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_);
+  EXPECT_EQ(1000, config.idleTimeout().value().count());
+}
+
+// Check that the default max request header count is 100.
+TEST_F(HttpConnectionManagerConfigTest, DefaultMaxRequestHeaderCount) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_);
+  EXPECT_EQ(100, config.maxRequestHeadersCount());
+}
+
+// Check that max request header count is configured.
+TEST_F(HttpConnectionManagerConfigTest, MaxRequestHeaderCountConfigurable) {
+  const std::string yaml_string = R"EOF(
+  stat_prefix: ingress_http
+  common_http_protocol_options:
+    max_headers_count: 200
+  route_config:
+    name: local_route
+  http_filters:
+  - name: envoy.router
+  )EOF";
+
+  HttpConnectionManagerConfig config(parseHttpConnectionManagerFromV2Yaml(yaml_string), context_,
+                                     date_provider_, route_config_provider_manager_,
+                                     scoped_routes_config_provider_manager_);
+  EXPECT_EQ(200, config.maxRequestHeadersCount());
+}
+
 TEST_F(HttpConnectionManagerConfigTest, ServerOverwrite) {
   const std::string yaml_string = R"EOF(
   stat_prefix: ingress_http

--- a/test/integration/autonomous_upstream.cc
+++ b/test/integration/autonomous_upstream.cc
@@ -63,7 +63,7 @@ AutonomousHttpConnection::AutonomousHttpConnection(SharedConnectionWrapper& shar
                                                    Stats::Store& store, Type type,
                                                    AutonomousUpstream& upstream)
     : FakeHttpConnection(shared_connection, store, type, upstream.timeSystem(),
-                         Http::DEFAULT_MAX_REQUEST_HEADERS_KB),
+                         Http::DEFAULT_MAX_REQUEST_HEADERS_KB, Http::DEFAULT_MAX_HEADERS_COUNT),
       upstream_(upstream) {}
 
 Http::StreamDecoder& AutonomousHttpConnection::newStream(Http::StreamEncoder& response_encoder,

--- a/test/integration/fake_upstream.h
+++ b/test/integration/fake_upstream.h
@@ -411,7 +411,8 @@ public:
   enum class Type { HTTP1, HTTP2 };
 
   FakeHttpConnection(SharedConnectionWrapper& shared_connection, Stats::Store& store, Type type,
-                     Event::TestTimeSystem& time_system, uint32_t max_request_headers_kb);
+                     Event::TestTimeSystem& time_system, uint32_t max_request_headers_kb,
+                     uint32_t max_request_headers_count);
 
   // By default waitForNewStream assumes the next event is a new stream and
   // returns AssertionFailure if an unexpected event occurs. If a caller truly
@@ -540,7 +541,8 @@ public:
   testing::AssertionResult
   waitForHttpConnection(Event::Dispatcher& client_dispatcher, FakeHttpConnectionPtr& connection,
                         std::chrono::milliseconds timeout = TestUtility::DefaultTimeout,
-                        uint32_t max_request_headers_kb = Http::DEFAULT_MAX_REQUEST_HEADERS_KB);
+                        uint32_t max_request_headers_kb = Http::DEFAULT_MAX_REQUEST_HEADERS_KB,
+                        uint32_t max_request_headers_count = Http::DEFAULT_MAX_HEADERS_COUNT);
 
   ABSL_MUST_USE_RESULT
   testing::AssertionResult

--- a/test/integration/http2_integration_test.cc
+++ b/test/integration/http2_integration_test.cc
@@ -64,6 +64,8 @@ TEST_P(Http2IntegrationTest, Retry) { testRetry(); }
 
 TEST_P(Http2IntegrationTest, RetryAttemptCount) { testRetryAttemptCountHeader(); }
 
+TEST_P(Http2IntegrationTest, LargeRequestTrailersRejected) { testLargeRequestTrailers(66, 60); }
+
 static std::string response_metadata_filter = R"EOF(
 name: response-metadata-filter
 config: {}

--- a/test/integration/http2_upstream_integration_test.cc
+++ b/test/integration/http2_upstream_integration_test.cc
@@ -371,4 +371,67 @@ config:
   EXPECT_TRUE(response->complete());
 }
 
+// Tests the default limit for the number of response headers is 100. Results in a stream reset if
+// exceeds.
+TEST_P(Http2UpstreamIntegrationTest, TestManyResponseHeadersRejected) {
+  // Default limit for response headers is 100.
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  Http::TestHeaderMapImpl many_headers(default_response_headers_);
+  for (int i = 0; i < 100; i++) {
+    many_headers.addCopy("many", std::string(1, 'a'));
+  }
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(many_headers, true);
+  response->waitForEndStream();
+  // Upstream stream reset triggered.
+  EXPECT_EQ("503", response->headers().Status()->value().getStringView());
+}
+
+// Tests bootstrap configuration of max response headers.
+TEST_P(Http2UpstreamIntegrationTest, ManyResponseHeadersAccepted) {
+  // Set max response header count to 200.
+  config_helper_.addConfigModifier([](envoy::config::bootstrap::v2::Bootstrap& bootstrap) {
+    auto* static_resources = bootstrap.mutable_static_resources();
+    auto* cluster = static_resources->mutable_clusters(0);
+    auto* http_protocol_options = cluster->mutable_common_http_protocol_options();
+    http_protocol_options->mutable_max_headers_count()->set_value(200);
+  });
+  Http::TestHeaderMapImpl response_headers(default_response_headers_);
+  for (int i = 0; i < 150; i++) {
+    response_headers.addCopy(std::to_string(i), std::string(1, 'a'));
+  }
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto response = codec_client_->makeRequestWithBody(default_request_headers_, 1024);
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(response_headers, false);
+  upstream_request_->encodeData(512, true);
+  response->waitForEndStream();
+
+  EXPECT_TRUE(upstream_request_->complete());
+  EXPECT_TRUE(response->complete());
+}
+
+// Tests that HTTP/2 response headers over 60 kB are rejected and result in a stream reset.
+TEST_P(Http2UpstreamIntegrationTest, LargeResponseHeadersRejected) {
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+
+  Http::TestHeaderMapImpl large_headers(default_response_headers_);
+  large_headers.addCopy("large", std::string(60 * 1024, 'a'));
+  auto response = codec_client_->makeHeaderOnlyRequest(default_request_headers_);
+  waitForNextUpstreamRequest();
+
+  upstream_request_->encodeHeaders(large_headers, true);
+  response->waitForEndStream();
+  // Upstream stream reset.
+  EXPECT_EQ("503", response->headers().Status()->value().getStringView());
+}
+
 } // namespace Envoy

--- a/test/integration/http2_upstream_integration_test.h
+++ b/test/integration/http2_upstream_integration_test.h
@@ -16,6 +16,8 @@ public:
     setUpstreamProtocol(FakeHttpConnection::Type::HTTP2);
   }
 
+  void initialize() override { HttpIntegrationTest::initialize(); }
+
   void bidirectionalStreaming(uint32_t bytes);
   void simultaneousRequest(uint32_t request1_bytes, uint32_t request2_bytes,
                            uint32_t response1_bytes, uint32_t response2_bytes);

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -122,18 +122,21 @@ protected:
   //
   // Waits for the complete downstream response before returning.
   // Requires |codec_client_| to be initialized.
-  IntegrationStreamDecoderPtr
-  sendRequestAndWaitForResponse(const Http::TestHeaderMapImpl& request_headers,
-                                uint32_t request_body_size,
-                                const Http::TestHeaderMapImpl& response_headers,
-                                uint32_t response_body_size, int upstream_index = 0);
+  IntegrationStreamDecoderPtr sendRequestAndWaitForResponse(
+      const Http::TestHeaderMapImpl& request_headers, uint32_t request_body_size,
+      const Http::TestHeaderMapImpl& response_headers, uint32_t response_body_size,
+      int upstream_index = 0, std::chrono::milliseconds time = TestUtility::DefaultTimeout);
 
   // Wait for the end of stream on the next upstream stream on any of the provided fake upstreams.
   // Sets fake_upstream_connection_ to the connection and upstream_request_ to stream.
   // In cases where the upstream that will receive the request is not deterministic, a second
   // upstream index may be provided, in which case both upstreams will be checked for requests.
-  uint64_t waitForNextUpstreamRequest(const std::vector<uint64_t>& upstream_indices);
-  void waitForNextUpstreamRequest(uint64_t upstream_index = 0);
+  uint64_t waitForNextUpstreamRequest(
+      const std::vector<uint64_t>& upstream_indices,
+      std::chrono::milliseconds connection_wait_timeout = TestUtility::DefaultTimeout);
+  void waitForNextUpstreamRequest(
+      uint64_t upstream_index = 0,
+      std::chrono::milliseconds connection_wait_timeout = TestUtility::DefaultTimeout);
 
   // Close |codec_client_| and |fake_upstream_connection_| cleanly.
   void cleanupUpstreamAndDownstream();
@@ -185,7 +188,11 @@ protected:
   void testRouterUpstreamResponseBeforeRequestComplete();
 
   void testTwoRequests(bool force_network_backup = false);
+  void testLargeHeaders(Http::TestHeaderMapImpl request_headers,
+                        Http::TestHeaderMapImpl request_trailers, uint32_t size, uint32_t max_size);
   void testLargeRequestHeaders(uint32_t size, uint32_t max_size = 60);
+  void testLargeRequestTrailers(uint32_t size, uint32_t max_size = 60);
+  void testManyRequestHeaders(std::chrono::milliseconds time = TestUtility::DefaultTimeout);
 
   void testAddEncodedTrailers();
   void testRetry();

--- a/test/integration/http_integration.h
+++ b/test/integration/http_integration.h
@@ -190,7 +190,8 @@ protected:
   void testTwoRequests(bool force_network_backup = false);
   void testLargeHeaders(Http::TestHeaderMapImpl request_headers,
                         Http::TestHeaderMapImpl request_trailers, uint32_t size, uint32_t max_size);
-  void testLargeRequestHeaders(uint32_t size, uint32_t max_size = 60);
+  void testLargeRequestHeaders(uint32_t size, uint32_t count, uint32_t max_size = 60,
+                               uint32_t max_count = 100);
   void testLargeRequestTrailers(uint32_t size, uint32_t max_size = 60);
   void testManyRequestHeaders(std::chrono::milliseconds time = TestUtility::DefaultTimeout);
 
@@ -228,6 +229,7 @@ protected:
   // The codec type for the client-to-Envoy connection
   Http::CodecClient::Type downstream_protocol_{Http::CodecClient::Type::HTTP1};
   uint32_t max_request_headers_kb_{Http::DEFAULT_MAX_REQUEST_HEADERS_KB};
+  uint32_t max_request_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   std::string access_log_name_;
 };
 } // namespace Envoy

--- a/test/integration/protocol_integration_test.cc
+++ b/test/integration/protocol_integration_test.cc
@@ -599,6 +599,16 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeCookieParsingConcatenated) {
 
 // Validate that lots of tiny cookies doesn't cause a DoS (many cookie headers).
 TEST_P(DownstreamProtocolIntegrationTest, LargeCookieParsingMany) {
+  // Set header count limit to 2010.
+  uint32_t max_count = 2010;
+  config_helper_.addConfigModifier(
+      [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
+          -> void {
+        hcm.mutable_common_http_protocol_options()->mutable_max_headers_count()->set_value(
+            max_count);
+      });
+  max_request_headers_count_ = max_count;
+
   initialize();
 
   codec_client_ = makeHttpConnection(lookupPort("http"));
@@ -883,11 +893,88 @@ name: decode-headers-only
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersRejected) {
-  testLargeRequestHeaders(95, 60);
+  // Send one 95 kB header with limit 60 kB and 100 headers.
+  testLargeRequestHeaders(95, 1, 60, 100);
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, LargeRequestHeadersAccepted) {
-  testLargeRequestHeaders(95, 96);
+  // Send one 95 kB header with limit 96 kB and 100 headers.
+  testLargeRequestHeaders(95, 1, 96, 100);
+}
+
+TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersRejected) {
+  // Send 101 empty headers with limit 60 kB and 100 headers.
+  testLargeRequestHeaders(0, 101, 60, 80);
+}
+
+TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersAccepted) {
+  // Send 145 empty headers with limit 60 kB and 150 headers.
+  testLargeRequestHeaders(0, 140, 60, 150);
+}
+
+TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersRejected) {
+  // Default header (and trailer) count limit is 100.
+  Http::TestHeaderMapImpl request_trailers;
+  for (int i = 0; i < 150; i++) {
+    request_trailers.addCopy("trailer", std::string(1, 'a'));
+  }
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+  codec_client_->sendData(*request_encoder_, 1, false);
+  codec_client_->sendTrailers(*request_encoder_, request_trailers);
+
+  // Only relevant to Http2Downstream.
+  if (downstream_protocol_ == Http::CodecClient::Type::HTTP1) {
+    // Http1 Downstream ignores trailers.
+    waitForNextUpstreamRequest();
+    upstream_request_->encodeHeaders(default_response_headers_, true);
+    response->waitForEndStream();
+    EXPECT_TRUE(response->complete());
+    EXPECT_EQ("200", response->headers().Status()->value().getStringView());
+  } else {
+    // Expect rejection.
+    // TODO(asraa): we shouldn't need this unexpected disconnect, but some tests hit unparented
+    // connections without it. Likely need to reconsider whether the waits/closes should be on
+    // client or upstream.
+    fake_upstreams_[0]->set_allow_unexpected_disconnects(true);
+    ASSERT_TRUE(fake_upstreams_[0]->waitForHttpConnection(*dispatcher_, fake_upstream_connection_));
+    response->waitForReset();
+    ASSERT_TRUE(fake_upstream_connection_->close());
+    ASSERT_TRUE(fake_upstream_connection_->waitForDisconnect());
+  }
+}
+
+TEST_P(DownstreamProtocolIntegrationTest, ManyRequestTrailersAccepted) {
+  // Set header (and trailer) count limit to 200.
+  uint32_t max_count = 200;
+  config_helper_.addConfigModifier(
+      [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
+          -> void {
+        hcm.mutable_common_http_protocol_options()->mutable_max_headers_count()->set_value(
+            max_count);
+      });
+  max_request_headers_count_ = max_count;
+  Http::TestHeaderMapImpl request_trailers;
+  for (int i = 0; i < 150; i++) {
+    request_trailers.addCopy("trailer", std::string(1, 'a'));
+  }
+
+  initialize();
+  codec_client_ = makeHttpConnection(lookupPort("http"));
+  auto encoder_decoder = codec_client_->startRequest(default_request_headers_);
+  request_encoder_ = &encoder_decoder.first;
+  auto response = std::move(encoder_decoder.second);
+  codec_client_->sendData(*request_encoder_, 1, false);
+  codec_client_->sendTrailers(*request_encoder_, request_trailers);
+  waitForNextUpstreamRequest();
+  upstream_request_->encodeHeaders(default_response_headers_, true);
+  response->waitForEndStream();
+  EXPECT_TRUE(response->complete());
+  EXPECT_EQ("200", response->headers().Status()->value().getStringView());
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ManyRequestHeadersTimeout) {
@@ -904,9 +991,16 @@ TEST_P(DownstreamProtocolIntegrationTest, LargeRequestTrailersRejected) {
 }
 
 TEST_P(DownstreamProtocolIntegrationTest, ManyTrailerHeaders) {
+  max_request_headers_kb_ = 96;
+  max_request_headers_count_ = 20005;
+
   config_helper_.addConfigModifier(
       [&](envoy::config::filter::network::http_connection_manager::v2::HttpConnectionManager& hcm)
-          -> void { hcm.mutable_max_request_headers_kb()->set_value(96); });
+          -> void {
+        hcm.mutable_max_request_headers_kb()->set_value(max_request_headers_kb_);
+        hcm.mutable_common_http_protocol_options()->mutable_max_headers_count()->set_value(
+            max_request_headers_count_);
+      });
 
   Http::TestHeaderMapImpl request_trailers{};
   for (int i = 0; i < 20000; i++) {

--- a/test/mocks/upstream/cluster_info.cc
+++ b/test/mocks/upstream/cluster_info.cc
@@ -48,6 +48,8 @@ MockClusterInfo::MockClusterInfo()
   ON_CALL(*this, eds_service_name()).WillByDefault(ReturnPointee(&eds_service_name_));
   ON_CALL(*this, http2Settings()).WillByDefault(ReturnRef(http2_settings_));
   ON_CALL(*this, extensionProtocolOptions(_)).WillByDefault(Return(extension_protocol_options_));
+  ON_CALL(*this, maxResponseHeadersCount())
+      .WillByDefault(ReturnPointee(&max_response_headers_count_));
   ON_CALL(*this, maxRequestsPerConnection())
       .WillByDefault(ReturnPointee(&max_requests_per_connection_));
   ON_CALL(*this, stats()).WillByDefault(ReturnRef(stats_));

--- a/test/mocks/upstream/cluster_info.h
+++ b/test/mocks/upstream/cluster_info.h
@@ -90,6 +90,7 @@ public:
   MOCK_CONST_METHOD0(lbOriginalDstConfig,
                      const absl::optional<envoy::api::v2::Cluster::OriginalDstLbConfig>&());
   MOCK_CONST_METHOD0(maintenanceMode, bool());
+  MOCK_CONST_METHOD0(maxResponseHeadersCount, uint32_t());
   MOCK_CONST_METHOD0(maxRequestsPerConnection, uint64_t());
   MOCK_CONST_METHOD0(name, const std::string&());
   MOCK_CONST_METHOD1(resourceManager, ResourceManager&(ResourcePriority priority));
@@ -112,6 +113,7 @@ public:
   Http::Http2Settings http2_settings_{};
   ProtocolOptionsConfigConstSharedPtr extension_protocol_options_;
   uint64_t max_requests_per_connection_{};
+  uint32_t max_response_headers_count_{Http::DEFAULT_MAX_HEADERS_COUNT};
   NiceMock<Stats::MockIsolatedStatsStore> stats_store_;
   ClusterStats stats_;
   Network::TransportSocketFactoryPtr transport_socket_factory_;


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:This PR cherry-picks the fixes for CVE-2019-15226 and CVE-2019-15225 to Envoy-wasm. 

Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
