### PR TITLE
Remove fake "envoy" module.

### DIFF
--- a/source/extensions/common/wasm/null/null_vm.cc
+++ b/source/extensions/common/wasm/null/null_vm.cc
@@ -36,11 +36,6 @@ bool NullVm::load(const std::string& name, bool /* allow_precompiled */) {
 
 void NullVm::link(absl::string_view /* name */) {}
 
-void NullVm::makeModule(absl::string_view /* name */) {
-  // NullVm does not advertise code as emscripten so this will not get called.
-  NOT_REACHED_GCOVR_EXCL_LINE;
-}
-
 void NullVm::start(Common::Wasm::Context* context) {
   SaveRestoreContext saved_context(context);
   plugin_->start();

--- a/source/extensions/common/wasm/null/null_vm.h
+++ b/source/extensions/common/wasm/null/null_vm.h
@@ -37,7 +37,6 @@ struct NullVm : public WasmVm {
   bool setMemory(uint64_t pointer, uint64_t size, const void* data) override;
   bool setWord(uint64_t pointer, Word data) override;
   bool getWord(uint64_t pointer, Word* data) override;
-  void makeModule(absl::string_view name) override;
   absl::string_view getUserSection(absl::string_view name) override;
 
 #define _FORWARD_GET_FUNCTION(_T)                                                                  \

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -2050,7 +2050,7 @@ std::string Plugin::makeLogPrefix() const {
 void Wasm::registerCallbacks() {
 #define _REGISTER(_fn)                                                                             \
   wasm_vm_->registerCallback(                                                                      \
-      "envoy", #_fn, &_fn##Handler,                                                                \
+      "env", #_fn, &_fn##Handler,                                                                  \
       &ConvertFunctionWordToUint32<decltype(_fn##Handler),                                         \
                                    _fn##Handler>::convertFunctionWordToUint32)
   if (is_emscripten_) {
@@ -2076,7 +2076,7 @@ void Wasm::registerCallbacks() {
   // Calls with the "proxy_" prefix.
 #define _REGISTER_PROXY(_fn)                                                                       \
   wasm_vm_->registerCallback(                                                                      \
-      "envoy", "proxy_" #_fn, &_fn##Handler,                                                       \
+      "env", "proxy_" #_fn, &_fn##Handler,                                                         \
       &ConvertFunctionWordToUint32<decltype(_fn##Handler),                                         \
                                    _fn##Handler>::convertFunctionWordToUint32);
   _REGISTER_PROXY(log);

--- a/source/extensions/common/wasm/wasm_vm.h
+++ b/source/extensions/common/wasm/wasm_vm.h
@@ -224,12 +224,6 @@ public:
   virtual bool setWord(uint64_t pointer, Word data) PURE;
 
   /**
-   * Make a new intrinsic module (e.g. for Emscripten support).
-   * @param name the name of the module to make.
-   */
-  virtual void makeModule(absl::string_view name) PURE;
-
-  /**
    * Get the contents of the user section with the given name or "" if it does not exist.
    * @param name the name of the user section to get.
    * @return the contents of the user section (if any). The result will be empty() if there


### PR DESCRIPTION
This module was previously used to prioritize the local ("envoy")
implementations of Emscripten functions over those from WAVM, but
we no longer import those, so this is no longer necessary.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>