### PR TITLE
Rename getUserSection to getCustomSection.

### DIFF
--- a/source/extensions/common/wasm/null/null_vm.cc
+++ b/source/extensions/common/wasm/null/null_vm.cc
@@ -92,7 +92,7 @@ bool NullVm::getWord(uint64_t pointer, Word* data) {
   return true;
 }
 
-absl::string_view NullVm::getUserSection(absl::string_view /* name */) {
+absl::string_view NullVm::getCustomSection(absl::string_view /* name */) {
   // Return nothing: there is no WASM file.
   return {};
 }

--- a/source/extensions/common/wasm/null/null_vm.h
+++ b/source/extensions/common/wasm/null/null_vm.h
@@ -38,7 +38,7 @@ struct NullVm : public WasmVm {
   bool setWord(uint64_t pointer, Word data) override;
   bool getWord(uint64_t pointer, Word* data) override;
   void makeModule(absl::string_view name) override;
-  absl::string_view getUserSection(absl::string_view name) override;
+  absl::string_view getCustomSection(absl::string_view name) override;
 
 #define _FORWARD_GET_FUNCTION(_T)                                                                  \
   void getFunction(absl::string_view function_name, _T* f) override {                              \

--- a/source/extensions/common/wasm/v8/v8.cc
+++ b/source/extensions/common/wasm/v8/v8.cc
@@ -41,7 +41,7 @@ public:
   absl::string_view runtime() override { return WasmRuntimeNames::get().v8; }
 
   bool load(const std::string& code, bool allow_precompiled) override;
-  absl::string_view getUserSection(absl::string_view name) override;
+  absl::string_view getCustomSection(absl::string_view name) override;
   void link(absl::string_view debug_name) override;
 
   // We don't care about this.
@@ -280,8 +280,8 @@ bool V8::load(const std::string& code, bool /* allow_precompiled */) {
   return module_ != nullptr;
 }
 
-absl::string_view V8::getUserSection(absl::string_view name) {
-  ENVOY_LOG(trace, "[wasm] getUserSection(\"{}\")", name);
+absl::string_view V8::getCustomSection(absl::string_view name) {
+  ENVOY_LOG(trace, "[wasm] getCustomSection(\"{}\")", name);
   ASSERT(source_.get() != nullptr);
 
   const byte_t* end = source_.get() + source_.size();
@@ -304,7 +304,7 @@ absl::string_view V8::getUserSection(absl::string_view name) {
       pos += len;
       rest -= (pos - start);
       if (len == name.size() && ::memcmp(pos - len, name.data(), len) == 0) {
-        ENVOY_LOG(trace, "[wasm] getUserSection(\"{}\") found, size: {}", name, rest);
+        ENVOY_LOG(trace, "[wasm] getCustomSection(\"{}\") found, size: {}", name, rest);
         return absl::string_view(pos, rest);
       }
     }

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -2208,7 +2208,7 @@ bool Wasm::initialize(const std::string& code, bool allow_precompiled) {
   if (!ok) {
     return false;
   }
-  auto metadata = wasm_vm_->getUserSection("emscripten_metadata");
+  auto metadata = wasm_vm_->getCustomSection("emscripten_metadata");
   if (!metadata.empty()) {
     // See https://github.com/emscripten-core/emscripten/blob/incoming/tools/shared.py#L3059
     is_emscripten_ = true;

--- a/source/extensions/common/wasm/wasm_vm.h
+++ b/source/extensions/common/wasm/wasm_vm.h
@@ -230,12 +230,12 @@ public:
   virtual void makeModule(absl::string_view name) PURE;
 
   /**
-   * Get the contents of the user section with the given name or "" if it does not exist.
-   * @param name the name of the user section to get.
-   * @return the contents of the user section (if any). The result will be empty() if there
+   * Get the contents of the custom section with the given name or "" if it does not exist.
+   * @param name the name of the custom section to get.
+   * @return the contents of the custom section (if any). The result will be empty if there
    * is no such section.
    */
-  virtual absl::string_view getUserSection(absl::string_view name) PURE;
+  virtual absl::string_view getCustomSection(absl::string_view name) PURE;
 
   /**
    * Get typed function exported by the WASM module.

--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -224,7 +224,7 @@ struct Wavm : public WasmVm {
   bool getWord(uint64_t pointer, Word* data) override;
   bool setWord(uint64_t pointer, Word data) override;
   void makeModule(absl::string_view name) override;
-  absl::string_view getUserSection(absl::string_view name) override;
+  absl::string_view getCustomSection(absl::string_view name) override;
 
   void getInstantiatedGlobals();
 
@@ -441,7 +441,7 @@ bool Wavm::setWord(uint64_t pointer, Word data) {
   return setMemory(pointer, sizeof(uint32_t), &data32);
 }
 
-absl::string_view Wavm::getUserSection(absl::string_view name) {
+absl::string_view Wavm::getCustomSection(absl::string_view name) {
   for (auto& section : ir_module_.customSections) {
     if (section.name == name) {
       return {reinterpret_cast<char*>(section.data.data()), section.data.size()};

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -56,7 +56,7 @@ TEST(WasmVmTest, NullVmStartup) {
   EXPECT_TRUE(wasm_vm->cloneable());
   auto wasm_vm_clone = wasm_vm->clone();
   EXPECT_TRUE(wasm_vm_clone != nullptr);
-  EXPECT_TRUE(wasm_vm->getUserSection("user").empty());
+  EXPECT_TRUE(wasm_vm->getCustomSection("user").empty());
 }
 
 TEST(WasmVmTest, NullVmMemory) {


### PR DESCRIPTION
The "custom section" is the official language used in the WebAssembly spec.

Inspired by a similar change in WAVM.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>