### PR TITLE
Remove support for __errno_location.

### DIFF
--- a/source/extensions/common/wasm/null/null_plugin.cc
+++ b/source/extensions/common/wasm/null/null_plugin.cc
@@ -164,12 +164,8 @@ void NullPlugin::getFunction(absl::string_view function_name, WasmCallVoid<8>* f
   }
 }
 
-void NullPlugin::getFunction(absl::string_view function_name, WasmCallWord<0>* f) {
-  if (function_name == "__errno_location") {
-    *f = [](Common::Wasm::Context*) -> Word { return Word(reinterpret_cast<uintptr_t>(&errno)); };
-  } else {
-    throw WasmVmException(fmt::format("Missing getFunction for: {}", function_name));
-  }
+void NullPlugin::getFunction(absl::string_view function_name, WasmCallWord<0>* /* f */) {
+  throw WasmVmException(fmt::format("Missing getFunction for: {}", function_name));
 }
 
 void NullPlugin::getFunction(absl::string_view function_name, WasmCallWord<1>* f) {

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -573,8 +573,6 @@ public:
     return true;
   }
 
-  void setErrno(int32_t err);
-
 private:
   friend class Context;
   // These are the same as the values of the Context::MetricType enum, here separately for
@@ -628,7 +626,6 @@ private:
 
   WasmCallWord<1> malloc_;
   WasmCallVoid<1> free_;
-  WasmCallWord<0> __errno_location_;
 
   // Calls into the VM.
   WasmCallWord<3> validateConfiguration_;


### PR DESCRIPTION
We don't need it anymore. Missed in #260.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>