### PR TITLE
Use connection's filter state object when available for filter state

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -344,10 +344,11 @@ WasmResult serializeValue(Filters::Common::Expr::CelValue value, std::string* re
 class WasmStateWrapper : public google::api::expr::runtime::CelMap {
 public:
   WasmStateWrapper(const StreamInfo::FilterState& filter_state,
-                     const StreamInfo::FilterState* connection_filter_state)
-        : filter_state_(filter_state), connection_filter_state_(connection_filter_state) {}
+                   const StreamInfo::FilterState* connection_filter_state)
+      : filter_state_(filter_state), connection_filter_state_(connection_filter_state) {}
   WasmStateWrapper(const StreamInfo::FilterState& filter_state)
-        : filter_state_(filter_state), connection_filter_state_(nullptr) {}absl::optional<google::api::expr::runtime::CelValue>
+      : filter_state_(filter_state), connection_filter_state_(nullptr) {}
+  absl::optional<google::api::expr::runtime::CelValue>
   operator[](google::api::expr::runtime::CelValue key) const override {
     if (!key.IsString()) {
       return {};
@@ -358,14 +359,14 @@ public:
       return google::api::expr::runtime::CelValue::CreateBytes(&result.value());
     } catch (const EnvoyException& e) {
       // If  doesn't exist in request filter state, try looking up in connection filter state.
-    try {
-      if (connection_filter_state_) {
-        const WasmState& result = connection_filter_state_->getDataReadOnly<WasmState>(value);
-        return google::api::expr::runtime::CelValue::CreateBytes(&result.value());
+      try {
+        if (connection_filter_state_) {
+          const WasmState& result = connection_filter_state_->getDataReadOnly<WasmState>(value);
+          return google::api::expr::runtime::CelValue::CreateBytes(&result.value());
+        }
+      } catch (const EnvoyException& e) {
+        return {};
       }
-    } catch (const EnvoyException& e) {
-      return {};
-    }
       return {};
     }
   }
@@ -441,12 +442,12 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
         break;
       case PropertyToken::FILTER_STATE:
         if (getConnection()) {
-                  value = CelValue::CreateMap(Protobuf::Arena::Create<WasmStateWrapper>(
-                      &arena, info->filterState(), &getConnection()->streamInfo().filterState()));
-                } else {
-                  value = CelValue::CreateMap(
-                      Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState()));
-                }
+          value = CelValue::CreateMap(Protobuf::Arena::Create<WasmStateWrapper>(
+              &arena, info->filterState(), &getConnection()->streamInfo().filterState()));
+        } else {
+          value = CelValue::CreateMap(
+              Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState()));
+        }
         break;
       case PropertyToken::REQUEST:
         value = CelValue::CreateMap(Protobuf::Arena::Create<Filters::Common::Expr::RequestWrapper>(

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -343,8 +343,11 @@ WasmResult serializeValue(Filters::Common::Expr::CelValue value, std::string* re
 // An expression wrapper for the WASM state
 class WasmStateWrapper : public google::api::expr::runtime::CelMap {
 public:
-  WasmStateWrapper(const StreamInfo::FilterState& filter_state) : filter_state_(filter_state) {}
-  absl::optional<google::api::expr::runtime::CelValue>
+  WasmStateWrapper(const StreamInfo::FilterState& filter_state,
+                     const StreamInfo::FilterState* connection_filter_state)
+        : filter_state_(filter_state), connection_filter_state_(connection_filter_state) {}
+  WasmStateWrapper(const StreamInfo::FilterState& filter_state)
+        : filter_state_(filter_state), connection_filter_state_(nullptr) {}absl::optional<google::api::expr::runtime::CelValue>
   operator[](google::api::expr::runtime::CelValue key) const override {
     if (!key.IsString()) {
       return {};
@@ -354,6 +357,15 @@ public:
       const WasmState& result = filter_state_.getDataReadOnly<WasmState>(value);
       return google::api::expr::runtime::CelValue::CreateBytes(&result.value());
     } catch (const EnvoyException& e) {
+      // If  doesn't exist in request filter state, try looking up in connection filter state.
+    try {
+      if (connection_filter_state_) {
+        const WasmState& result = connection_filter_state_->getDataReadOnly<WasmState>(value);
+        return google::api::expr::runtime::CelValue::CreateBytes(&result.value());
+      }
+    } catch (const EnvoyException& e) {
+      return {};
+    }
       return {};
     }
   }
@@ -365,6 +377,7 @@ public:
 
 private:
   const StreamInfo::FilterState& filter_state_;
+  const StreamInfo::FilterState* connection_filter_state_;
 };
 
 #define PROPERTY_TOKENS(_f)                                                                        \
@@ -427,8 +440,13 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
         value = CelValue::CreateMessage(&info->dynamicMetadata(), &arena);
         break;
       case PropertyToken::FILTER_STATE:
-        value = CelValue::CreateMap(
-            Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState()));
+        if (getConnection()) {
+                  value = CelValue::CreateMap(Protobuf::Arena::Create<WasmStateWrapper>(
+                      &arena, info->filterState(), &getConnection()->streamInfo().filterState()));
+                } else {
+                  value = CelValue::CreateMap(
+                      Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState()));
+                }
         break;
       case PropertyToken::REQUEST:
         value = CelValue::CreateMap(Protobuf::Arena::Create<Filters::Common::Expr::RequestWrapper>(
@@ -970,6 +988,15 @@ StreamInfo::StreamInfo* Context::getRequestStreamInfo() const {
     return &network_read_filter_callbacks_->connection().streamInfo();
   } else if (network_write_filter_callbacks_) {
     return &network_write_filter_callbacks_->connection().streamInfo();
+  }
+  return nullptr;
+}
+
+const Network::Connection* Context::getConnection() const {
+  if (encoder_callbacks_) {
+    return encoder_callbacks_->connection();
+  } else if (decoder_callbacks_) {
+    return decoder_callbacks_->connection();
   }
   return nullptr;
 }

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -441,9 +441,10 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
         value = CelValue::CreateMessage(&info->dynamicMetadata(), &arena);
         break;
       case PropertyToken::FILTER_STATE:
-        if (getConnection()) {
+        const Envoy::Network::Connection* connection = getConnection();
+        if (connection) {
           value = CelValue::CreateMap(Protobuf::Arena::Create<WasmStateWrapper>(
-              &arena, info->filterState(), &getConnection()->streamInfo().filterState()));
+              &arena, info->filterState(), &connection->streamInfo().filterState()));
         } else {
           value = CelValue::CreateMap(
               Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState()));

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -440,7 +440,7 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
       case PropertyToken::METADATA:
         value = CelValue::CreateMessage(&info->dynamicMetadata(), &arena);
         break;
-      case PropertyToken::FILTER_STATE:
+      case PropertyToken::FILTER_STATE: {
         const Envoy::Network::Connection* connection = getConnection();
         if (connection) {
           value = CelValue::CreateMap(Protobuf::Arena::Create<WasmStateWrapper>(
@@ -450,6 +450,7 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
               Protobuf::Arena::Create<WasmStateWrapper>(&arena, info->filterState()));
         }
         break;
+      }
       case PropertyToken::REQUEST:
         value = CelValue::CreateMap(Protobuf::Arena::Create<Filters::Common::Expr::RequestWrapper>(
             &arena, request_headers, *info));

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -85,6 +85,13 @@ public:
   const StreamInfo::StreamInfo* getConstRequestStreamInfo() const;
   StreamInfo::StreamInfo* getRequestStreamInfo() const;
 
+  // Retrieves the connection object associated with the request (a.k.a active stream).
+    // It selects a value based on the following order: encoder callback, decoder
+    // callback. As long as any one of the callbacks is invoked, the value should be
+    // available.
+    const Network::Connection* getConnection() const;
+
+
   //
   // VM level downcalls into the WASM code on Context(id == 0).
   //

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -86,11 +86,10 @@ public:
   StreamInfo::StreamInfo* getRequestStreamInfo() const;
 
   // Retrieves the connection object associated with the request (a.k.a active stream).
-    // It selects a value based on the following order: encoder callback, decoder
-    // callback. As long as any one of the callbacks is invoked, the value should be
-    // available.
-    const Network::Connection* getConnection() const;
-
+  // It selects a value based on the following order: encoder callback, decoder
+  // callback. As long as any one of the callbacks is invoked, the value should be
+  // available.
+  const Network::Connection* getConnection() const;
 
   //
   // VM level downcalls into the WASM code on Context(id == 0).

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -51,6 +51,7 @@ namespace Common {
 namespace Wasm {
 
 namespace {
+
 std::atomic<int64_t> active_wasm_;
 
 std::string base64Sha256(absl::string_view data) {

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -51,7 +51,6 @@ namespace Common {
 namespace Wasm {
 
 namespace {
-
 std::atomic<int64_t> active_wasm_;
 
 std::string base64Sha256(absl::string_view data) {


### PR DESCRIPTION
Use connection's filter state object when available as compared to request's filter state object

Description: Use connection's filter state object when available as compared to request's filter state object
Risk Level: Medium
Testing: Test in Istio/Proxy
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
