### PR TITLE
wasm: fix V8 running under ASan without setup_clang. (#9036)

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -33,9 +33,9 @@ export NM=$${NM:-nm}
 if [[ $${ENVOY_ASAN-} == "1" ]]; then
   WEE8_BUILD_ARGS+=" is_asan=true"
   WEE8_BUILD_ARGS+=" is_lsan=true"
-  WEE8_BUILD_ARGS+=" is_ubsan=true"
 fi
 if [[ $${ENVOY_UBSAN_VPTR-} == "1" ]]; then
+  WEE8_BUILD_ARGS+=" is_ubsan=true"
   WEE8_BUILD_ARGS+=" is_ubsan_vptr=true"
 fi
 if [[ $${ENVOY_MSAN-} == "1" ]]; then


### PR DESCRIPTION
* wasm: fix V8 running under ASan without setup_clang.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>
Signed-off-by: Lizan Zhou <lizan@tetrate.io>
