### PR TITLE
wasm: make V8-based runtime cloneable.

### DIFF
--- a/source/extensions/common/wasm/null/null_vm.h
+++ b/source/extensions/common/wasm/null/null_vm.h
@@ -32,7 +32,7 @@ struct NullVm : public WasmVmBase {
 
   // WasmVm
   absl::string_view runtime() override { return WasmRuntimeNames::get().Null; }
-  bool cloneable() override { return true; };
+  Cloneable cloneable() override { return Cloneable::InstantiatedModule; };
   WasmVmPtr clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;
   void link(absl::string_view debug_name) override;

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -1608,7 +1608,7 @@ bool Wasm::initialize(const std::string& code, bool allow_precompiled) {
     allow_precompiled_ = allow_precompiled;
   }
 
-  if (started_from_ < Cloneable::InstantiatedModule) {
+  if (started_from_ != Cloneable::InstantiatedModule) {
     registerCallbacks();
     wasm_vm_->link(vm_id_);
   }
@@ -1616,7 +1616,7 @@ bool Wasm::initialize(const std::string& code, bool allow_precompiled) {
   vm_context_ = std::make_shared<Context>(this);
   getFunctions();
 
-  if (started_from_ < Cloneable::InstantiatedModule) {
+  if (started_from_ != Cloneable::InstantiatedModule) {
     // Base VM was already started, so don't try to start cloned VMs again.
     startVm(vm_context_.get());
   }

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -1407,9 +1407,7 @@ void Wasm::registerCallbacks() {
       "env", #_fn, &Exports::_fn,                                                                  \
       &ConvertFunctionWordToUint32<decltype(Exports::_fn),                                         \
                                    Exports::_fn>::convertFunctionWordToUint32)
-  if (is_emscripten_) {
-    _REGISTER(pthread_equal);
-  }
+  _REGISTER(pthread_equal);
 #undef _REGISTER
 
 #define _REGISTER_WASI(_fn)                                                                        \
@@ -1417,14 +1415,12 @@ void Wasm::registerCallbacks() {
       "wasi_unstable", #_fn, &Exports::wasi_unstable_##_fn,                                        \
       &ConvertFunctionWordToUint32<decltype(Exports::wasi_unstable_##_fn),                         \
                                    Exports::wasi_unstable_##_fn>::convertFunctionWordToUint32)
-  if (is_emscripten_) {
-    _REGISTER_WASI(fd_write);
-    _REGISTER_WASI(fd_seek);
-    _REGISTER_WASI(fd_close);
-    _REGISTER_WASI(environ_get);
-    _REGISTER_WASI(environ_sizes_get);
-    _REGISTER_WASI(proc_exit);
-  }
+  _REGISTER_WASI(fd_write);
+  _REGISTER_WASI(fd_seek);
+  _REGISTER_WASI(fd_close);
+  _REGISTER_WASI(environ_get);
+  _REGISTER_WASI(environ_sizes_get);
+  _REGISTER_WASI(proc_exit);
 #undef _REGISTER_WASI
 
   // Calls with the "proxy_" prefix.
@@ -1535,19 +1531,17 @@ void Wasm::getFunctions() {
 
 Wasm::Wasm(const Wasm& wasm, Event::Dispatcher& dispatcher)
     : std::enable_shared_from_this<Wasm>(wasm), vm_id_(wasm.vm_id_),
-      vm_id_with_hash_(wasm.vm_id_with_hash_), scope_(wasm.scope_),
-      cluster_manager_(wasm.cluster_manager_), dispatcher_(dispatcher),
+      vm_id_with_hash_(wasm.vm_id_with_hash_), started_from_(wasm.wasm_vm()->cloneable()),
+      scope_(wasm.scope_), cluster_manager_(wasm.cluster_manager_), dispatcher_(dispatcher),
       time_source_(dispatcher.timeSource()), wasm_stats_(wasm.wasm_stats_),
       stat_name_set_(wasm.stat_name_set_) {
-  if (wasm.wasm_vm()->cloneable()) {
+  if (started_from_ != Cloneable::NotCloneable) {
     wasm_vm_ = wasm.wasm_vm()->clone();
-    vm_context_ = std::make_shared<Context>(this);
-    getFunctions();
   } else {
     wasm_vm_ = Common::Wasm::createWasmVm(wasm.wasm_vm()->runtime(), scope_);
-    if (!initialize(wasm.code(), wasm.allow_precompiled())) {
-      throw WasmException("Failed to initialize WASM code");
-    }
+  }
+  if (!initialize(wasm.code(), wasm.allow_precompiled())) {
+    throw WasmException("Failed to load WASM code");
   }
   active_wasm_++;
   wasm_stats_.active_.set(active_wasm_);
@@ -1571,50 +1565,62 @@ bool Wasm::initialize(const std::string& code, bool allow_precompiled) {
     return false;
   }
 
-  // Construct a unique identifier for the VM based on the provided vm_id and a hash of the
-  // code.
-  vm_id_with_hash_ = vm_id_ + ":" + base64Sha256(code);
+  if (started_from_ == Cloneable::NotCloneable) {
+    // Construct a unique identifier for the VM based on the provided vm_id and a hash of the
+    // code.
+    vm_id_with_hash_ = vm_id_ + ":" + base64Sha256(code);
 
-  auto ok = wasm_vm_->load(code, allow_precompiled);
-  if (!ok) {
-    return false;
-  }
-  auto metadata = wasm_vm_->getCustomSection("emscripten_metadata");
-  if (!metadata.empty()) {
-    // See https://github.com/emscripten-core/emscripten/blob/incoming/tools/shared.py#L3059
-    is_emscripten_ = true;
-    auto start = reinterpret_cast<const uint8_t*>(metadata.data());
-    auto end = reinterpret_cast<const uint8_t*>(metadata.data() + metadata.size());
-    start = decodeVarint(start, end, &emscripten_metadata_major_version_);
-    start = decodeVarint(start, end, &emscripten_metadata_minor_version_);
-    start = decodeVarint(start, end, &emscripten_abi_major_version_);
-    start = decodeVarint(start, end, &emscripten_abi_minor_version_);
-    uint32_t temp;
-    if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 1) {
-      // metadata 0.2 - added: wasm_backend.
-      start = decodeVarint(start, end, &temp);
+    auto ok = wasm_vm_->load(code, allow_precompiled);
+    if (!ok) {
+      return false;
     }
-    start = decodeVarint(start, end, &temp);
-    start = decodeVarint(start, end, &temp);
-    if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 0) {
-      // metadata 0.1 - added: global_base, dynamic_base, dynamictop_ptr and tempdouble_ptr.
+    auto metadata = wasm_vm_->getCustomSection("emscripten_metadata");
+    if (!metadata.empty()) {
+      // See https://github.com/emscripten-core/emscripten/blob/incoming/tools/shared.py#L3059
+      is_emscripten_ = true;
+      auto start = reinterpret_cast<const uint8_t*>(metadata.data());
+      auto end = reinterpret_cast<const uint8_t*>(metadata.data() + metadata.size());
+      start = decodeVarint(start, end, &emscripten_metadata_major_version_);
+      start = decodeVarint(start, end, &emscripten_metadata_minor_version_);
+      start = decodeVarint(start, end, &emscripten_abi_major_version_);
+      start = decodeVarint(start, end, &emscripten_abi_minor_version_);
+      uint32_t temp;
+      if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 1) {
+        // metadata 0.2 - added: wasm_backend.
+        start = decodeVarint(start, end, &temp);
+      }
       start = decodeVarint(start, end, &temp);
       start = decodeVarint(start, end, &temp);
-      start = decodeVarint(start, end, &temp);
-      decodeVarint(start, end, &temp);
-      if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 2) {
-        // metadata 0.3 - added: standalone_wasm.
-        start = decodeVarint(start, end, &emscripten_standalone_wasm_);
+      if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 0) {
+        // metadata 0.1 - added: global_base, dynamic_base, dynamictop_ptr and tempdouble_ptr.
+        start = decodeVarint(start, end, &temp);
+        start = decodeVarint(start, end, &temp);
+        start = decodeVarint(start, end, &temp);
+        decodeVarint(start, end, &temp);
+        if (emscripten_metadata_major_version_ > 0 || emscripten_metadata_minor_version_ > 2) {
+          // metadata 0.3 - added: standalone_wasm.
+          start = decodeVarint(start, end, &emscripten_standalone_wasm_);
+        }
       }
     }
+
+    code_ = code;
+    allow_precompiled_ = allow_precompiled;
   }
-  registerCallbacks();
-  wasm_vm_->link(vm_id_);
+
+  if (started_from_ < Cloneable::InstantiatedModule) {
+    registerCallbacks();
+    wasm_vm_->link(vm_id_);
+  }
+
   vm_context_ = std::make_shared<Context>(this);
   getFunctions();
-  startVm(vm_context_.get());
-  code_ = code;
-  allow_precompiled_ = allow_precompiled;
+
+  if (started_from_ < Cloneable::InstantiatedModule) {
+    // Base VM was already started, so don't try to start cloned VMs again.
+    startVm(vm_context_.get());
+  }
+
   return true;
 }
 

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -579,6 +579,7 @@ private:
   std::string vm_id_;           // User-provided vm_id.
   std::string vm_id_with_hash_; // vm_id + hash of code.
   std::unique_ptr<WasmVm> wasm_vm_;
+  Cloneable started_from_{Cloneable::NotCloneable};
   Stats::ScopeSharedPtr scope_;
 
   Upstream::ClusterManager& cluster_manager_;

--- a/source/extensions/common/wasm/wasm_vm.h
+++ b/source/extensions/common/wasm/wasm_vm.h
@@ -124,6 +124,8 @@ using WasmCallback_dd = double (*)(void*, double);
                       _f(WasmCallback_WWl) _f(WasmCallback_WWlWW) _f(WasmCallback_WWm)             \
                           _f(WasmCallback_dd)
 
+enum class Cloneable { NotCloneable, CompiledBytecode, InstantiatedModule };
+
 // Wasm VM instance. Provides the low level WASM interface.
 class WasmVm : public Logger::Loggable<Logger::Id::wasm> {
 public:
@@ -145,7 +147,7 @@ public:
    * VM from scratch for each worker.
    * @return true if the VM is cloneable.
    */
-  virtual bool cloneable() PURE;
+  virtual Cloneable cloneable() PURE;
 
   /**
    * Make a worker/thread-specific copy if supported by the underlying VM system (see cloneable()

--- a/source/extensions/common/wasm/wavm/wavm.cc
+++ b/source/extensions/common/wasm/wavm/wavm.cc
@@ -178,7 +178,7 @@ struct Wavm : public WasmVmBase {
 
   // WasmVm
   absl::string_view runtime() override { return WasmRuntimeNames::get().Wavm; }
-  bool cloneable() override { return true; };
+  Cloneable cloneable() override { return Cloneable::InstantiatedModule; };
   std::unique_ptr<WasmVm> clone() override;
   bool load(const std::string& code, bool allow_precompiled) override;
   void link(absl::string_view debug_name) override;

--- a/test/extensions/common/wasm/wasm_vm_test.cc
+++ b/test/extensions/common/wasm/wasm_vm_test.cc
@@ -69,7 +69,7 @@ TEST_F(BaseVmTest, NullVmStartup) {
   auto wasm_vm = createWasmVm("envoy.wasm.runtime.null", scope_);
   EXPECT_TRUE(wasm_vm != nullptr);
   EXPECT_TRUE(wasm_vm->runtime() == "envoy.wasm.runtime.null");
-  EXPECT_TRUE(wasm_vm->cloneable());
+  EXPECT_TRUE(wasm_vm->cloneable() == Cloneable::InstantiatedModule);
   auto wasm_vm_clone = wasm_vm->clone();
   EXPECT_TRUE(wasm_vm_clone != nullptr);
   EXPECT_TRUE(wasm_vm->getCustomSection("user").empty());
@@ -141,10 +141,7 @@ TEST_F(WasmVmTest, V8BadCode) {
 TEST_F(WasmVmTest, V8Code) {
   auto wasm_vm = createWasmVm("envoy.wasm.runtime.v8", scope_);
   ASSERT_TRUE(wasm_vm != nullptr);
-
   EXPECT_TRUE(wasm_vm->runtime() == "envoy.wasm.runtime.v8");
-  EXPECT_FALSE(wasm_vm->cloneable());
-  EXPECT_TRUE(wasm_vm->clone() == nullptr);
 
   auto code = TestEnvironment::readFileToStringForTest(TestEnvironment::substitute(
       "{{ test_rundir }}/test/extensions/common/wasm/test_data/test_rust.wasm"));
@@ -152,6 +149,9 @@ TEST_F(WasmVmTest, V8Code) {
 
   EXPECT_THAT(wasm_vm->getCustomSection("producers"), HasSubstr("rustc"));
   EXPECT_TRUE(wasm_vm->getCustomSection("emscripten_metadata").empty());
+
+  EXPECT_TRUE(wasm_vm->cloneable() == Cloneable::CompiledBytecode);
+  EXPECT_TRUE(wasm_vm->clone() != nullptr);
 }
 
 TEST_F(WasmVmTest, V8BadHostFunctions) {


### PR DESCRIPTION
Fixes #161.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>