### PR TITLE
bazel: replace tclap mirror. (#9072)

### DIFF
--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -128,7 +128,7 @@ def envoy_dependencies(skip_targets = []):
     _com_github_circonus_labs_libcircllhist()
     _com_github_cyan4973_xxhash()
     _com_github_datadog_dd_opentracing_cpp()
-    _com_github_eile_tclap()
+    _com_github_mirror_tclap()
     _com_github_envoyproxy_sqlparser()
     _com_github_fmtlib_fmt()
     _com_github_gabime_spdlog()
@@ -243,14 +243,14 @@ def _com_github_envoyproxy_sqlparser():
         actual = "@com_github_envoyproxy_sqlparser//:sqlparser",
     )
 
-def _com_github_eile_tclap():
+def _com_github_mirror_tclap():
     _repository_impl(
-        name = "com_github_eile_tclap",
+        name = "com_github_mirror_tclap",
         build_file = "@envoy//bazel/external:tclap.BUILD",
     )
     native.bind(
         name = "tclap",
-        actual = "@com_github_eile_tclap//:tclap",
+        actual = "@com_github_mirror_tclap//:tclap",
     )
 
 def _com_github_fmtlib_fmt():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -73,7 +73,7 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "sql-parser-5f50c68bdf5f107692bb027d1c568f67597f4d7f",
         urls = ["https://github.com/envoyproxy/sql-parser/archive/5f50c68bdf5f107692bb027d1c568f67597f4d7f.tar.gz"],
     ),
-    com_github_eile_tclap = dict(
+    com_github_mirror_tclap = dict(
         sha256 = "f0ede0721dddbb5eba3a47385a6e8681b14f155e1129dd39d1a959411935098f",
         strip_prefix = "tclap-tclap-1-2-1-release-final",
         urls = ["https://github.com/mirror/tclap/archive/tclap-1-2-1-release-final.tar.gz"],


### PR DESCRIPTION
Description:

Change (non-existent) https://github.com/eile/tclap/ to https://github.com/mirror/tclap/. I didn't validate the new mirror in any way, but the downloded release file sha256sum stays the same. In the future the releases should probably be downloaded from the real upstream. However the release 1.2.1 tarball from https://sourceforge.net/projects/tclap/files/ did not have the same sha256sum as the release file which Envoy uses.

Risk Level: Medium
Testing: N/A
Docs Changes: N/A
Release Notes:
Fixes #9071

Signed-off-by: Ismo Puustinen <ismo.puustinen@intel.com>
Signed-off-by: Piotr Sikora <piotrsikora@google.com>