### PR TITLE
build: support linux-aarch64

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,11 +27,13 @@ build:linux --copt=-fPIC
 # We already have absl in the build, define absl=1 to tell googletest to use absl for backtrace.
 build --define absl=1
 
-# Pass PATH, CC, CXX and LLVM_CONFIG variables from the environment.
+# Pass PATH, CC, CXX, LLVM_CONFIG, GN and NINJA variables from the environment.
 build --action_env=CC
 build --action_env=CXX
 build --action_env=LLVM_CONFIG
 build --action_env=PATH
+build --action_env=GN
+build --action_env=NINJA
 
 # Common flags for sanitizers
 build:sanitizer --define tcmalloc=disabled

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -2,9 +2,9 @@
 
 set -e
 
-# This works only on Linux-x86_64 and macOS-x86_64.
-if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || `uname -m` != "x86_64" ]]; then
-  echo "ERROR: wee8 is currently supported only on Linux-x86_64 and macOS-x86_64."
+# This works only on Linux-x86_64, Linux-aarch64 and macOS-x86_64.
+if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || ( `uname -m` != "x86_64" && `uname -m` != "aarch64" ) ]]; then
+  echo "ERROR: wee8 is currently supported only on Linux-x86_64, Linux-aarch64 and macOS-x86_64."
   exit 1
 fi
 
@@ -28,6 +28,17 @@ fi
 
 export AR=$${AR:-ar}
 export NM=$${NM:-nm}
+
+GN=`which gn`
+if [[ "$${GN}" == "" ]]; then
+   echo "gn: no such file in PATH, use gn in wee8"
+   export GN=buildtools/linux64/gn
+fi
+NINJA=`which ninja`
+if [[ "$${NINJA}" == "" ]]; then
+   echo "ninja: no such file in PATH, use ninja in wee8"
+   export NINJA=third_party/depot_tools/ninja
+fi
 
 # Hook sanitizers.
 if [[ $${ENVOY_ASAN-} == "1" ]]; then
@@ -75,9 +86,9 @@ WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
 if [[ `uname` == "Darwin" ]]; then
   buildtools/mac/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
 else
-  buildtools/linux64/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  $${GN} gen out/wee8 --args="$$WEE8_BUILD_ARGS"
 fi
-third_party/depot_tools/ninja -C out/wee8 wee8
+$${NINJA} -C out/wee8 wee8
 
 # Move compiled library to the expected destinations.
 popd

--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -28,17 +28,8 @@ fi
 
 export AR=$${AR:-ar}
 export NM=$${NM:-nm}
-
-GN=`which gn`
-if [[ "$${GN}" == "" ]]; then
-   echo "gn: no such file in PATH, use gn in wee8"
-   export GN=buildtools/linux64/gn
-fi
-NINJA=`which ninja`
-if [[ "$${NINJA}" == "" ]]; then
-   echo "ninja: no such file in PATH, use ninja in wee8"
-   export NINJA=third_party/depot_tools/ninja
-fi
+export GN=$${GN-buildtools/linux64/gn}
+export NINJA=$${NINJA:-third_party/depot_tools/ninja}
 
 # Hook sanitizers.
 if [[ $${ENVOY_ASAN-} == "1" ]]; then


### PR DESCRIPTION
Using native commands gn and ninja, we successfully compiled on aarch64.

Signed-off-by: Dongyuan Tang <tangdongyuan@huawei.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: In the old file wee8.genrule_cmd, it does not support aarch64, and v8 default gn and ninja do not support aarch64 architecture. Gn and ninja using aarch64 native command can compile successfully.
Risk Level: low
Testing: manual testing
Docs Changes: N/A
Release Notes: N/A
[Optional Fixes #Issue]
[Optional Deprecated:]
