### PR TITLE
wasm: drop absl from time and duration

### DIFF
--- a/api/wasm/cpp/proxy_wasm_api.h
+++ b/api/wasm/cpp/proxy_wasm_api.h
@@ -476,7 +476,22 @@ inline Optional<WasmDataPtr> getProperty(std::initializer_list<StringView> parts
   return std::make_unique<WasmData>(value_ptr, value_size);
 }
 
-inline bool getStringValue(std::initializer_list<StringView> parts, std::string* out) {
+// Generic property reader for basic types: int64, uint64, double, bool
+// Durations are represented as int64 nanoseconds.
+// Timetamps are represented as int64 Unix nanoseconds.
+template <typename T>
+inline bool getValue(std::initializer_list<StringView> parts, T* out) {
+  auto buf = getProperty(parts);
+  if (!buf.has_value() || buf.value()->size() != sizeof(T)) {
+    return false;
+  }
+  *out = *reinterpret_cast<const T*>(buf.value()->data());
+  return true;
+}
+
+// Specialization for bytes and string values
+template <>
+inline bool getValue<std::string>(std::initializer_list<StringView> parts, std::string* out) {
   auto buf = getProperty(parts);
   if (!buf.has_value()) {
     return false;
@@ -485,22 +500,19 @@ inline bool getStringValue(std::initializer_list<StringView> parts, std::string*
   return true;
 }
 
-inline bool getStructValue(std::initializer_list<StringView> parts,
-                           google::protobuf::Struct* value_ptr) {
+// Specialization for message types (including struct value for lists and maps)
+template <typename T>
+inline bool getMessageValue(std::initializer_list<StringView> parts,
+                            T* value_ptr) {
   auto buf = getProperty(parts);
   if (!buf.has_value()) {
     return false;
   }
-  return value_ptr->ParseFromArray(buf.value()->data(), buf.value()->size());
-}
-
-template <typename T> inline bool getValue(std::initializer_list<StringView> parts, T* out) {
-  auto buf = getProperty(parts);
-  if (!buf.has_value() || buf.value()->size() != sizeof(T)) {
-    return false;
+  if (buf.value()->size() == 0) {
+    value_ptr = nullptr;
+    return true;
   }
-  *out = *reinterpret_cast<const T*>(buf.value()->data());
-  return true;
+  return value_ptr->ParseFromArray(buf.value()->data(), buf.value()->size());
 }
 
 inline WasmResult setFilterState(StringView key, StringView value) {

--- a/api/wasm/cpp/proxy_wasm_api.h
+++ b/api/wasm/cpp/proxy_wasm_api.h
@@ -478,7 +478,8 @@ inline Optional<WasmDataPtr> getProperty(std::initializer_list<StringView> parts
 
 // Generic property reader for basic types: int64, uint64, double, bool
 // Durations are represented as int64 nanoseconds.
-// Timetamps are represented as int64 Unix nanoseconds.
+// Timestamps are represented as int64 Unix nanoseconds.
+// Strings and bytes are represented as std::string.
 template <typename T>
 inline bool getValue(std::initializer_list<StringView> parts, T* out) {
   auto buf = getProperty(parts);

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -293,13 +293,15 @@ WasmResult serializeValue(Filters::Common::Expr::CelValue value, std::string* re
     return WasmResult::Ok;
   }
   case CelValue::Type::kDuration: {
-    auto out = value.DurationOrDie();
-    result->assign(reinterpret_cast<const char*>(&out), sizeof(absl::Duration));
+    // Warning: loss of precision to nano-seconds
+    int64_t out = absl::ToInt64Nanoseconds(value.DurationOrDie());
+    result->assign(reinterpret_cast<const char*>(&out), sizeof(int64_t));
     return WasmResult::Ok;
   }
   case CelValue::Type::kTimestamp: {
-    auto out = value.TimestampOrDie();
-    result->assign(reinterpret_cast<const char*>(&out), sizeof(absl::Time));
+    // Warning: loss of precision to nano-seconds
+    int64_t out = absl::ToUnixNanos(value.TimestampOrDie());
+    result->assign(reinterpret_cast<const char*>(&out), sizeof(int64_t));
     return WasmResult::Ok;
   }
   case CelValue::Type::kMessage: {

--- a/test/extensions/filters/http/wasm/test_data/metadata_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/metadata_cpp.cc
@@ -23,7 +23,7 @@ static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleCon
 
 void ExampleRootContext::onTick() {
   std::string value;
-  if (!getStringValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
+  if (!getValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
     logDebug("missing node metadata");
   }
   logDebug(std::string("onTick ") + value);
@@ -31,7 +31,7 @@ void ExampleRootContext::onTick() {
 
 FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
   std::string value;
-  if (!getStringValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
+  if (!getValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
     logDebug("missing node metadata");
   }
   auto r = setFilterStateStringValue("wasm_request_set_key", "wasm_request_set_value");
@@ -47,18 +47,18 @@ FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
 
 FilterDataStatus ExampleContext::onRequestBody(size_t body_buffer_length, bool end_of_stream) {
   std::string value;
-  if (!getStringValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
+  if (!getValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
     logDebug("missing node metadata");
   }
   logError(std::string("onRequestBody ") + value);
   std::string request_string;
   std::string request_string2;
-  if (!getStringValue(
+  if (!getValue(
           {"metadata", "filter_metadata", "envoy.filters.http.wasm", "wasm_request_get_key"},
           &request_string)) {
     logDebug("missing request metadata");
   }
-  if (!getStringValue(
+  if (!getValue(
           {"metadata", "filter_metadata", "envoy.filters.http.wasm", "wasm_request_get_key"},
           &request_string2)) {
     logDebug("missing request metadata");


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

We cannot compile absl to Wasm since it has many system calls.

/assign @jplevyak @bianpengyuan 
