### PR TITLE
Enable v8 build on Arm64 server

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -2,9 +2,9 @@
 
 set -e
 
-# This works only on Linux-x86_64 and macOS-x86_64.
-if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || `uname -m` != "x86_64" ]]; then
-  echo "ERROR: wee8 is currently supported only on Linux-x86_64 and macOS-x86_64."
+# This works only on Linux-x86_64, Linux-aarch64 and macOS-x86_64.
+if [[ ( `uname` != "Linux" && `uname` != "Darwin" ) || ( `uname -m` != "x86_64" && `uname -m` != "aarch64" ) ]]; then
+  echo "ERROR: wee8 is currently supported only on Linux-x86_64, Linux-aarch64 and macOS-x86_64."
   exit 1
 fi
 
@@ -70,14 +70,23 @@ WEE8_BUILD_ARGS+=" v8_use_external_startup_data=false"
 # Disable read-only heap, since it's leaky and HEAPCHECK complains about it.
 # TODO(PiotrSikora): remove when fixed upstream.
 WEE8_BUILD_ARGS+=" v8_enable_shared_ro_heap=false"
+# Support Arm64
+if [[ `uname -m` == "aarch64" ]]; then
+  WEE8_BUILD_ARGS+=" target_cpu=\"arm64\""
+fi
 
 # Build wee8.
 if [[ `uname` == "Darwin" ]]; then
   buildtools/mac/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  third_party/depot_tools/ninja -C out/wee8 wee8
+elif [[ `uname -m` == "aarch64" ]]; then
+  # On arm64 platform, use the system tool.
+  gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  ninja -C out/wee8 wee8
 else
-  buildtools/linux64/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  third_party/depot_tools/gn gen out/wee8 --args="$$WEE8_BUILD_ARGS"
+  third_party/depot_tools/ninja -C out/wee8 wee8
 fi
-third_party/depot_tools/ninja -C out/wee8 wee8
 
 # Move compiled library to the expected destinations.
 popd


### PR DESCRIPTION
This patch enables the v8 build on Arm64 native building environments
for envoy. There are some modifications about wee8 building scripts
listed as following:
1. Add "target_cpu" parameter into configuration files for Arm64
supporting
2. Modify the corresponding variable in building scripts.

Signed-off-by: Jingzhao <Jingzhao.Ni@arm.com>

