### PR TITLE
feat(context): add suppport for getting the grpc_status code

### DIFF
--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -139,6 +139,14 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
     return CelValue::CreateMap(&trailers_);
   } else if (value == Flags) {
     return CelValue::CreateInt64(info_.responseFlags());
+  } else if (value == GrpcStatus) {
+    if (trailers_.value_ != nullptr && trailers_.value_->GrpcStatus()) {
+      return convertHeaderEntry(trailers_.value_->GrpcStatus());
+    }
+    if (headers_.value_ != nullptr && headers_.value_->GrpcStatus()) {
+      return convertHeaderEntry(headers_.value_->GrpcStatus());
+    }
+    return {};
   }
   return {};
 }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -38,6 +38,7 @@ constexpr absl::string_view Response = "response";
 constexpr absl::string_view Code = "code";
 constexpr absl::string_view Trailers = "trailers";
 constexpr absl::string_view Flags = "flags";
+constexpr absl::string_view GrpcStatus = "grpc_status";
 
 // Per-request or per-connection metadata
 constexpr absl::string_view Metadata = "metadata";
@@ -79,6 +80,7 @@ public:
 
 private:
   friend class RequestWrapper;
+  friend class ResponseWrapper;
   const Http::HeaderMap* value_;
 };
 

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -197,8 +197,9 @@ TEST(Context, ResponseAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   const std::string header_name = "test-header";
   const std::string trailer_name = "test-trailer";
+  const std::string grpc_status = "grpc-status";
   Http::TestHeaderMapImpl header_map{{header_name, "a"}};
-  Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+  Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}, {grpc_status, "8"}};
   ResponseWrapper response(&header_map, &trailer_map, info);
 
   EXPECT_CALL(info, responseCode()).WillRepeatedly(Return(404));
@@ -252,7 +253,7 @@ TEST(Context, ResponseAttributes) {
     ASSERT_TRUE(value.value().IsMap());
     auto& map = *value.value().MapOrDie();
     EXPECT_FALSE(map.empty());
-    EXPECT_EQ(1, map.size());
+    EXPECT_EQ(2, map.size());
 
     auto header = map[CelValue::CreateString(&trailer_name)];
     EXPECT_TRUE(header.has_value());
@@ -264,6 +265,12 @@ TEST(Context, ResponseAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(0x1, value.value().Int64OrDie());
+  }
+  {
+    auto value = response[CelValue::CreateStringView(GrpcStatus)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsString());
+    EXPECT_EQ("8", value.value().StringOrDie().value());
   }
 }
 


### PR DESCRIPTION
Description: This PR allows access to the gRPC status codes via the common filter context. This will make it possible to report gRPC status codes in metrics and logs. This is a part of the work from: https://tinyurl.com/yy2cwmv5. A companion PR that hopes to use this code is https://github.com/istio/proxy/pull/2624.
Risk Level: Low
Testing: Unit
Docs Changes:
Release Notes:

cc: @kyessenov 

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>