### PR TITLE
feat(context): add response.grpc_status (#9693)

### DIFF
--- a/docs/root/intro/arch_overview/security/rbac_filter.rst
+++ b/docs/root/intro/arch_overview/security/rbac_filter.rst
@@ -79,6 +79,7 @@ The following attributes are exposed to the language runtime:
    request.total_size, int, Total size of the request including the headers
    request.protocol, string, Request protocol e.g. "HTTP/2"
    response.code, int, Response HTTP status code
+   response.grpc_status, int, Response gRPC status code
    response.headers, string map, All response headers
    response.trailers, string map, All response trailers
    response.size, int, Size of the response body

--- a/source/common/grpc/common.cc
+++ b/source/common/grpc/common.cc
@@ -63,6 +63,34 @@ absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& 
   return {static_cast<Status::GrpcStatus>(grpc_status_code)};
 }
 
+absl::optional<Status::GrpcStatus> Common::getGrpcStatus(const Http::HeaderMap& trailers,
+                                                         const Http::HeaderMap& headers,
+                                                         const StreamInfo::StreamInfo& info,
+                                                         bool allow_user_defined) {
+  // The gRPC specification does not guarantee a gRPC status code will be returned from a gRPC
+  // request. When it is returned, it will be in the response trailers. With that said, Envoy will
+  // treat a trailers-only response as a headers-only response, so we have to check the following
+  // in order:
+  //   1. trailers gRPC status, if it exists.
+  //   2. headers gRPC status, if it exists.
+  //   3. Inferred from info HTTP status, if it exists.
+  const std::array<absl::optional<Grpc::Status::GrpcStatus>, 3> optional_statuses = {{
+      {Grpc::Common::getGrpcStatus(trailers, allow_user_defined)},
+      {Grpc::Common::getGrpcStatus(headers, allow_user_defined)},
+      {info.responseCode() ? absl::optional<Grpc::Status::GrpcStatus>(
+                                 Grpc::Utility::httpToGrpcStatus(info.responseCode().value()))
+                           : absl::nullopt},
+  }};
+
+  for (const auto& optional_status : optional_statuses) {
+    if (optional_status.has_value()) {
+      return optional_status;
+    }
+  }
+
+  return absl::nullopt;
+}
+
 std::string Common::getGrpcMessage(const Http::HeaderMap& trailers) {
   const auto entry = trailers.GrpcMessage();
   return entry ? std::string(entry->value().getStringView()) : EMPTY_STRING;

--- a/source/common/grpc/common.h
+++ b/source/common/grpc/common.h
@@ -55,6 +55,20 @@ public:
                                                           bool allow_user_defined = false);
 
   /**
+   * Returns the GrpcStatus code from the set of trailers, headers, and StreamInfo, if present.
+   * @param trailers the trailers to parse for a status code
+   * @param headers the headers to parse if no status code was found in the trailers
+   * @param info the StreamInfo to check for HTTP response code if no code was found in the trailers
+   * or headers
+   * @return absl::optional<Status::GrpcStatus> the parsed status code or absl::nullopt if no status
+   * is found
+   */
+  static absl::optional<Status::GrpcStatus> getGrpcStatus(const Http::HeaderMap& trailers,
+                                                          const Http::HeaderMap& headers,
+                                                          const StreamInfo::StreamInfo& info,
+                                                          bool allow_user_defined = false);
+
+  /**
    * Returns the grpc-message from a given set of trailers, if present.
    * @param trailers the trailers to parse.
    * @return std::string the gRPC status message or empty string if grpc-message is not present in

--- a/source/extensions/filters/common/expr/BUILD
+++ b/source/extensions/filters/common/expr/BUILD
@@ -28,6 +28,7 @@ envoy_cc_library(
     srcs = ["context.cc"],
     hdrs = ["context.h"],
     deps = [
+        "//source/common/grpc:common_lib",
         "//source/common/http:utility_lib",
         "//source/common/stream_info:utility_lib",
         "@com_google_cel_cpp//eval/public:cel_value",

--- a/source/extensions/filters/common/expr/context.cc
+++ b/source/extensions/filters/common/expr/context.cc
@@ -1,5 +1,6 @@
 #include "extensions/filters/common/expr/context.h"
 
+#include "common/grpc/common.h"
 #include "common/http/utility.h"
 
 #include "absl/strings/numbers.h"
@@ -139,6 +140,13 @@ absl::optional<CelValue> ResponseWrapper::operator[](CelValue key) const {
     return CelValue::CreateMap(&trailers_);
   } else if (value == Flags) {
     return CelValue::CreateInt64(info_.responseFlags());
+  } else if (value == GrpcStatus) {
+    auto const& optional_status =
+        Grpc::Common::getGrpcStatus(*(trailers_.value_), *(headers_.value_), info_);
+    if (optional_status.has_value()) {
+      return CelValue::CreateInt64(optional_status.value());
+    }
+    return {};
   }
   return {};
 }

--- a/source/extensions/filters/common/expr/context.h
+++ b/source/extensions/filters/common/expr/context.h
@@ -3,6 +3,7 @@
 #include "envoy/config/core/v3/base.pb.h"
 #include "envoy/stream_info/stream_info.h"
 
+#include "common/grpc/status.h"
 #include "common/http/headers.h"
 
 #include "eval/public/cel_value.h"
@@ -38,6 +39,7 @@ constexpr absl::string_view Response = "response";
 constexpr absl::string_view Code = "code";
 constexpr absl::string_view Trailers = "trailers";
 constexpr absl::string_view Flags = "flags";
+constexpr absl::string_view GrpcStatus = "grpc_status";
 
 // Per-request or per-connection metadata
 constexpr absl::string_view Metadata = "metadata";
@@ -79,6 +81,7 @@ public:
 
 private:
   friend class RequestWrapper;
+  friend class ResponseWrapper;
   const Http::HeaderMap* value_;
 };
 

--- a/test/extensions/filters/common/expr/context_test.cc
+++ b/test/extensions/filters/common/expr/context_test.cc
@@ -197,8 +197,9 @@ TEST(Context, ResponseAttributes) {
   NiceMock<StreamInfo::MockStreamInfo> info;
   const std::string header_name = "test-header";
   const std::string trailer_name = "test-trailer";
+  const std::string grpc_status = "grpc-status";
   Http::TestHeaderMapImpl header_map{{header_name, "a"}};
-  Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+  Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}, {grpc_status, "8"}};
   ResponseWrapper response(&header_map, &trailer_map, info);
 
   EXPECT_CALL(info, responseCode()).WillRepeatedly(Return(404));
@@ -252,7 +253,7 @@ TEST(Context, ResponseAttributes) {
     ASSERT_TRUE(value.value().IsMap());
     auto& map = *value.value().MapOrDie();
     EXPECT_FALSE(map.empty());
-    EXPECT_EQ(1, map.size());
+    EXPECT_EQ(2, map.size());
 
     auto header = map[CelValue::CreateString(&trailer_name)];
     EXPECT_TRUE(header.has_value());
@@ -264,6 +265,38 @@ TEST(Context, ResponseAttributes) {
     EXPECT_TRUE(value.has_value());
     ASSERT_TRUE(value.value().IsInt64());
     EXPECT_EQ(0x1, value.value().Int64OrDie());
+  }
+  {
+    auto value = response[CelValue::CreateStringView(GrpcStatus)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    EXPECT_EQ(0x8, value.value().Int64OrDie());
+  }
+  {
+    Http::TestHeaderMapImpl header_map{{header_name, "a"}, {grpc_status, "7"}};
+    Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+    ResponseWrapper response_header_status(&header_map, &trailer_map, info);
+    auto value = response_header_status[CelValue::CreateStringView(GrpcStatus)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    EXPECT_EQ(0x7, value.value().Int64OrDie());
+  }
+  {
+    Http::TestHeaderMapImpl header_map{{header_name, "a"}};
+    Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+    ResponseWrapper response_no_status(&header_map, &trailer_map, info);
+    auto value = response_no_status[CelValue::CreateStringView(GrpcStatus)];
+    EXPECT_TRUE(value.has_value());
+    ASSERT_TRUE(value.value().IsInt64());
+    EXPECT_EQ(0xc, value.value().Int64OrDie()); // http:404 -> grpc:12
+  }
+  {
+    NiceMock<StreamInfo::MockStreamInfo> info_without_code;
+    Http::TestHeaderMapImpl header_map{{header_name, "a"}};
+    Http::TestHeaderMapImpl trailer_map{{trailer_name, "b"}};
+    ResponseWrapper response_no_status(&header_map, &trailer_map, info_without_code);
+    auto value = response_no_status[CelValue::CreateStringView(GrpcStatus)];
+    EXPECT_FALSE(value.has_value());
   }
 }
 


### PR DESCRIPTION
Cherry-pick of commit e9624ce64df2f44acdca46efeb928e1d1c0b74c0 from envoyproxy/envoy.

Per discussion in meeting about pulling in grpc-status support for Istio 1.5 release.

Signed-off-by: Douglas Reid <douglas-reid@users.noreply.github.com>


