### PR TITLE
wasm: expose proxy_expr in bazel, fix TSAN warning in ANTLR

### DIFF
--- a/api/wasm/cpp/contrib/BUILD
+++ b/api/wasm/cpp/contrib/BUILD
@@ -1,0 +1,17 @@
+licenses(["notice"])  # Apache 2
+
+load(
+    "//bazel:envoy_build_system.bzl",
+    "envoy_cc_library",
+    "envoy_package",
+)
+
+envoy_package()
+
+envoy_cc_library(
+    name = "contrib_lib",
+    hdrs = [
+        "proxy_expr.h",
+    ],
+)
+

--- a/bazel/antlr.patch
+++ b/bazel/antlr.patch
@@ -24,4 +24,3 @@ index 827c3d59f..62914cf55 100755
    _mode = mode;
    ssize_t mark = input->mark();
 
-d

--- a/bazel/antlr.patch
+++ b/bazel/antlr.patch
@@ -11,4 +11,17 @@ index c6cceda13..e86533759 100755
  }
 
  ATNDeserializer::ATNDeserializer(const ATNDeserializationOptions& dso): deserializationOptions(dso) {
+diff --git a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+index 827c3d59f..62914cf55 100755
+--- a/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
++++ b/runtime/Cpp/runtime/src/atn/LexerATNSimulator.cpp
+@@ -69,7 +69,7 @@ void LexerATNSimulator::copyState(LexerATNSimulator *simulator) {
+ }
 
+ size_t LexerATNSimulator::match(CharStream *input, size_t mode) {
+-  match_calls++;
++  // match_calls++;
+   _mode = mode;
+   ssize_t mark = input->mark();
+
+d


### PR DESCRIPTION
Signed-off-by: Kuat Yessenov <kuat@google.com>

TSAN detected an (innocent) data race in ANTLR parser.
Also, add a build file so we can see it in bazel.

/assign @PiotrSikora 
/assign @jplevyak 