### PR TITLE
Add access to upstreamfilterstate in WasmStateWrapper

### DIFF
--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -239,6 +239,12 @@ void Filter::initialize(Network::ReadFilterCallbacks& callbacks, bool set_connec
   getStreamInfo().setDownstreamLocalAddress(read_callbacks_->connection().localAddress());
   getStreamInfo().setDownstreamRemoteAddress(read_callbacks_->connection().remoteAddress());
   getStreamInfo().setDownstreamSslConnection(read_callbacks_->connection().ssl());
+  read_callbacks_->connection().streamInfo().setDownstreamLocalAddress(
+      read_callbacks_->connection().localAddress());
+  read_callbacks_->connection().streamInfo().setDownstreamRemoteAddress(
+      read_callbacks_->connection().remoteAddress());
+  read_callbacks_->connection().streamInfo().setDownstreamSslConnection(
+      read_callbacks_->connection().ssl());
 
   // Need to disable reads so that we don't write to an upstream that might fail
   // in onData(). This will get re-enabled when the upstream connection is
@@ -469,6 +475,10 @@ void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
   getStreamInfo().onUpstreamHostSelected(host);
   getStreamInfo().setUpstreamLocalAddress(connection.localAddress());
   getStreamInfo().setUpstreamSslConnection(connection.streamInfo().downstreamSslConnection());
+  read_callbacks_->connection().streamInfo().onUpstreamHostSelected(host);
+  read_callbacks_->connection().streamInfo().setUpstreamLocalAddress(connection.localAddress());
+  read_callbacks_->connection().streamInfo().setUpstreamSslConnection(
+      connection.streamInfo().downstreamSslConnection());
   read_callbacks_->connection().streamInfo().setUpstreamFilterState(
       connection.streamInfo().filterState());
 

--- a/source/common/tcp_proxy/tcp_proxy.cc
+++ b/source/common/tcp_proxy/tcp_proxy.cc
@@ -239,12 +239,6 @@ void Filter::initialize(Network::ReadFilterCallbacks& callbacks, bool set_connec
   getStreamInfo().setDownstreamLocalAddress(read_callbacks_->connection().localAddress());
   getStreamInfo().setDownstreamRemoteAddress(read_callbacks_->connection().remoteAddress());
   getStreamInfo().setDownstreamSslConnection(read_callbacks_->connection().ssl());
-  read_callbacks_->connection().streamInfo().setDownstreamLocalAddress(
-      read_callbacks_->connection().localAddress());
-  read_callbacks_->connection().streamInfo().setDownstreamRemoteAddress(
-      read_callbacks_->connection().remoteAddress());
-  read_callbacks_->connection().streamInfo().setDownstreamSslConnection(
-      read_callbacks_->connection().ssl());
 
   // Need to disable reads so that we don't write to an upstream that might fail
   // in onData(). This will get re-enabled when the upstream connection is
@@ -475,10 +469,6 @@ void Filter::onPoolReady(Tcp::ConnectionPool::ConnectionDataPtr&& conn_data,
   getStreamInfo().onUpstreamHostSelected(host);
   getStreamInfo().setUpstreamLocalAddress(connection.localAddress());
   getStreamInfo().setUpstreamSslConnection(connection.streamInfo().downstreamSslConnection());
-  read_callbacks_->connection().streamInfo().onUpstreamHostSelected(host);
-  read_callbacks_->connection().streamInfo().setUpstreamLocalAddress(connection.localAddress());
-  read_callbacks_->connection().streamInfo().setUpstreamSslConnection(
-      connection.streamInfo().downstreamSslConnection());
   read_callbacks_->connection().streamInfo().setUpstreamFilterState(
       connection.streamInfo().filterState());
 


### PR DESCRIPTION
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)
Add access to upstreamfilterstate in WasmStateWrapper 

Description: 
Risk Level:
Ref:  https://github.com/istio/istio/issues/20802
Testing: Tested E2E in istio/proxy
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
