### PR TITLE
Fix bad merge.

### DIFF
--- a/api/envoy/config/accesslog/v2/wasm.proto
+++ b/api/envoy/config/accesslog/v2/wasm.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.acces
 // [#protodoc-title: Wasm access log]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`
-// that calls into a WASM VM. Configures the built-in *envoy.wasm_access_log*
+// that calls into a WASM VM. Configures the built-in *envoy.access_loggers.wasm*
 // AccessLog.
 message WasmAccessLog {
   wasm.v2.PluginConfig config = 1;

--- a/api/envoy/extensions/access_loggers/wasm/v3/wasm.proto
+++ b/api/envoy/extensions/access_loggers/wasm/v3/wasm.proto
@@ -17,7 +17,7 @@ option java_multiple_files = true;
 // [#protodoc-title: Wasm access log]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`
-// that calls into a WASM VM. Configures the built-in *envoy.wasm_access_log*
+// that calls into a WASM VM. Configures the built-in *envoy.access_loggers.wasm*
 // AccessLog.
 message WasmAccessLog {
   option (udpa.annotations.versioning).previous_message_type =

--- a/generated_api_shadow/envoy/config/accesslog/v2/wasm.proto
+++ b/generated_api_shadow/envoy/config/accesslog/v2/wasm.proto
@@ -17,7 +17,7 @@ option (udpa.annotations.file_migrate).move_to_package = "envoy.extensions.acces
 // [#protodoc-title: Wasm access log]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.filter.accesslog.v2.AccessLog>`
-// that calls into a WASM VM. Configures the built-in *envoy.wasm_access_log*
+// that calls into a WASM VM. Configures the built-in *envoy.access_loggers.wasm*
 // AccessLog.
 message WasmAccessLog {
   wasm.v2.PluginConfig config = 1;

--- a/generated_api_shadow/envoy/extensions/access_loggers/wasm/v3/wasm.proto
+++ b/generated_api_shadow/envoy/extensions/access_loggers/wasm/v3/wasm.proto
@@ -17,7 +17,7 @@ option java_multiple_files = true;
 // [#protodoc-title: Wasm access log]
 
 // Custom configuration for an :ref:`AccessLog <envoy_api_msg_config.accesslog.v3.AccessLog>`
-// that calls into a WASM VM. Configures the built-in *envoy.wasm_access_log*
+// that calls into a WASM VM. Configures the built-in *envoy.access_loggers.wasm*
 // AccessLog.
 message WasmAccessLog {
   option (udpa.annotations.versioning).previous_message_type =

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -79,9 +79,8 @@ WasmAccessLogFactory::convertJsonFormatToMap(ProtobufWkt::Struct json_format) {
 /**
  * Static registration for the wasm access log. @see RegisterFactory.
  */
-static Registry::RegisterFactory<WasmAccessLogFactory,
-                                 Server::Configuration::AccessLogInstanceFactory>
-    register_;
+REGISTER_FACTORY(WasmAccessLogFactory,
+                 Server::Configuration::AccessLogInstanceFactory){"envoy.wasm_access_log"};
 
 } // namespace Wasm
 } // namespace AccessLoggers

--- a/source/extensions/access_loggers/well_known_names.h
+++ b/source/extensions/access_loggers/well_known_names.h
@@ -19,9 +19,9 @@ public:
   // HTTP gRPC access log
   const std::string HttpGrpc = "envoy.access_loggers.http_grpc";
   // TCP gRPC access log
-  const std::string TcpGrpc = "envoy.tcp_grpc_access_log";
+  const std::string TcpGrpc = "envoy.access_loggers.tcp_grpc";
   // WASM access log
-  const std::string Wasm = "envoy.wasm_access_log";
+  const std::string Wasm = "envoy.access_loggers.wasm";
 };
 
 using AccessLogNames = ConstSingleton<AccessLogNameValues>;

--- a/source/extensions/common/wasm/foreign.cc
+++ b/source/extensions/common/wasm/foreign.cc
@@ -31,7 +31,7 @@ public:
     return f;
   }
 };
-static Registry::RegisterFactory<CompressFactory, ForeignFunctionFactory> register_compress_;
+REGISTER_FACTORY(CompressFactory, ForeignFunctionFactory);
 
 class UncompressFactory : public ForeignFunctionFactory {
 public:
@@ -59,7 +59,7 @@ public:
     return f;
   }
 };
-static Registry::RegisterFactory<UncompressFactory, ForeignFunctionFactory> register_uncompress_;
+REGISTER_FACTORY(UncompressFactory, ForeignFunctionFactory);
 
 class ExpressionFactory : public Logger::Loggable<Logger::Id::wasm> {
 protected:
@@ -145,8 +145,7 @@ public:
     return f;
   }
 };
-static Registry::RegisterFactory<CreateExpressionFactory, ForeignFunctionFactory>
-    register_expr_create_;
+REGISTER_FACTORY(CreateExpressionFactory, ForeignFunctionFactory);
 
 class EvaluateExpressionFactory : public ExpressionFactory, public ForeignFunctionFactory {
 public:
@@ -181,8 +180,7 @@ public:
     return f;
   }
 };
-static Registry::RegisterFactory<EvaluateExpressionFactory, ForeignFunctionFactory>
-    register_expr_evaluate_;
+REGISTER_FACTORY(EvaluateExpressionFactory, ForeignFunctionFactory);
 
 class DeleteExpressionFactory : public ExpressionFactory, public ForeignFunctionFactory {
 public:
@@ -201,8 +199,7 @@ public:
     return f;
   }
 };
-static Registry::RegisterFactory<DeleteExpressionFactory, ForeignFunctionFactory>
-    register_expr_delete_;
+REGISTER_FACTORY(DeleteExpressionFactory, ForeignFunctionFactory);
 
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/common/wasm/null/sample_plugin/plugin_wrapper.cc
+++ b/source/extensions/common/wasm/null/sample_plugin/plugin_wrapper.cc
@@ -28,7 +28,7 @@ public:
 /**
  * Static registration for the null Wasm filter. @see RegisterFactory.
  */
-static Registry::RegisterFactory<SamplePluginFactory, NullVmPluginFactory> register_;
+REGISTER_FACTORY(SamplePluginFactory, NullVmPluginFactory);
 
 } // namespace Plugin
 } // namespace Null

--- a/source/extensions/wasm/config.cc
+++ b/source/extensions/wasm/config.cc
@@ -54,7 +54,7 @@ void WasmFactory::createWasm(const envoy::extensions::wasm::v3::WasmService& con
 /**
  * Static registration for the wasm factory. @see RegistryFactory.
  */
-static Registry::RegisterFactory<WasmFactory, Server::Configuration::WasmFactory> registered_;
+REGISTER_FACTORY(WasmFactory, Server::Configuration::WasmFactory);
 
 } // namespace Wasm
 } // namespace Extensions


### PR DESCRIPTION
While there, migrate Wasm access logger to the new-style name,
and switch to the REGISTER_FACTORY macro.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>