### PR TITLE
ci: increase timeout for a few //test/common/stats:... tests.

### DIFF
--- a/test/common/stats/BUILD
+++ b/test/common/stats/BUILD
@@ -122,6 +122,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "symbol_table_impl_test",
+    size = "large",
     srcs = ["symbol_table_impl_test.cc"],
     external_deps = ["abseil_hash_testing"],
     deps = [
@@ -190,6 +191,7 @@ envoy_cc_test(
 
 envoy_cc_test(
     name = "thread_local_store_test",
+    size = "large",
     srcs = ["thread_local_store_test.cc"],
     deps = [
         ":stat_test_utility_lib",


### PR DESCRIPTION
Those tests occasionally timeout on istio/envoy CI.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>