### PR TITLE
ci: skip hardcoded TAP tests.

### DIFF
--- a/ci/do_ci.sh
+++ b/ci/do_ci.sh
@@ -151,21 +151,6 @@ elif [[ "$CI_TARGET" == "bazel.asan" ]]; then
   echo "bazel ASAN/UBSAN debug build with tests"
   echo "Building and testing envoy tests ${TEST_TARGETS}"
   bazel_with_collection test ${BAZEL_BUILD_OPTIONS} ${TEST_TARGETS}
-  # Also validate that integration test traffic tapping (useful when debugging etc.)
-  # works. This requires that we set TAP_PATH. We do this under bazel.asan to
-  # ensure a debug build in CI.
-  echo "Validating integration test traffic tapping..."
-  TAP_TMP=/tmp/tap/
-  rm -rf "${TAP_TMP}"
-  mkdir -p "${TAP_TMP}"
-  bazel_with_collection test ${BAZEL_BUILD_OPTIONS} \
-    --strategy=TestRunner=local --test_env=TAP_PATH="${TAP_TMP}/tap" \
-    --test_env=PATH="/usr/sbin:${PATH}" \
-    //test/extensions/transport_sockets/tls/integration:ssl_integration_test
-  # Verify that some pb_text files have been created. We can't check for pcap,
-  # since tcpdump is not available in general due to CircleCI lack of support
-  # for privileged Docker executors.
-  ls -l "${TAP_TMP}"/tap_*.pb_text > /dev/null
   exit 0
 elif [[ "$CI_TARGET" == "bazel.tsan" ]]; then
   setup_clang_toolchain


### PR DESCRIPTION
Those tests depend on tcpdump and require privileged permissions,
so they fail (timeout) and CircleCI.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>