### PR TITLE
Restore and fix the Wasm Service.

### DIFF
--- a/include/envoy/server/wasm.h
+++ b/include/envoy/server/wasm.h
@@ -5,6 +5,7 @@
 #include "envoy/common/exception.h"
 #include "envoy/common/pure.h"
 #include "envoy/event/dispatcher.h"
+#include "envoy/thread_local/thread_local.h"
 
 #include "common/common/logger.h"
 
@@ -17,7 +18,19 @@ public:
 };
 
 using WasmSharedPtr = std::shared_ptr<Wasm>;
-using CreateWasmCallback = std::function<void(WasmSharedPtr)>;
+
+class WasmService {
+public:
+  WasmService(WasmSharedPtr singleton) : singleton_(std::move(singleton)) {}
+  WasmService(ThreadLocal::SlotPtr tls_slot) : tls_slot_(std::move(tls_slot)) {}
+
+private:
+  WasmSharedPtr singleton_;
+  ThreadLocal::SlotPtr tls_slot_;
+};
+
+using WasmServicePtr = std::unique_ptr<WasmService>;
+using CreateWasmServiceCallback = std::function<void(WasmServicePtr)>;
 
 } // namespace Server
 } // namespace Envoy

--- a/include/envoy/server/wasm_config.h
+++ b/include/envoy/server/wasm_config.h
@@ -70,12 +70,12 @@ public:
    * @param config const ProtoBuf::Message& supplies the config for the resource monitor
    *        implementation.
    * @param context WasmFactoryContext& supplies the resource monitor's context.
-   * @param cb CreateWasmCallback&& supplies the callback to be called after wasm is created.
+   * @param cb CreateWasmServiceCallback&& supplies the callback to be called after wasm is created.
    * @throw EnvoyException if the implementation is unable to produce an instance with
    *        the provided parameters.
    */
   virtual void createWasm(const envoy::extensions::wasm::v3::WasmService& config,
-                          WasmFactoryContext& context, CreateWasmCallback&& cb) PURE;
+                          WasmFactoryContext& context, CreateWasmServiceCallback&& cb) PURE;
 };
 
 } // namespace Configuration

--- a/source/extensions/wasm/config.cc
+++ b/source/extensions/wasm/config.cc
@@ -18,33 +18,33 @@ static const std::string INLINE_STRING = "<inline>";
 
 void WasmFactory::createWasm(const envoy::extensions::wasm::v3::WasmService& config,
                              Server::Configuration::WasmFactoryContext& context,
-                             Server::CreateWasmCallback&& cb) {
+                             Server::CreateWasmServiceCallback&& cb) {
   auto plugin = std::make_shared<Common::Wasm::Plugin>(
       config.config().name(), config.config().root_id(), config.config().vm_config().vm_id(),
       envoy::config::core::v3::TrafficDirection::UNSPECIFIED, context.localInfo(), nullptr);
 
   auto configuration = std::make_shared<std::string>(config.config().configuration());
   bool singleton = config.singleton();
-  auto callback = [&context, configuration, singleton, plugin, cb,
-                   this](Common::Wasm::WasmHandleSharedPtr base_wasm) {
+  auto callback = [&context, configuration, singleton, plugin,
+                   cb](Common::Wasm::WasmHandleSharedPtr base_wasm) {
     if (singleton) {
       // Return the WASM VM which will be stored as a singleton by the Server.
       auto root_context = base_wasm->wasm()->getOrCreateRootContext(plugin);
       if (!base_wasm->wasm()->configure(root_context, plugin, *configuration)) {
         cb(nullptr);
       }
-      return cb(base_wasm);
+      return cb(std::make_unique<Server::WasmService>(base_wasm));
     }
     // Per-thread WASM VM.
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
-    tls_slot_ = context.threadLocal().allocateSlot();
-    tls_slot_->set([base_wasm, plugin, configuration](Event::Dispatcher& dispatcher) {
+    auto tls_slot = context.threadLocal().allocateSlot();
+    tls_slot->set([base_wasm, plugin, configuration](Event::Dispatcher& dispatcher) {
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
           Common::Wasm::getOrCreateThreadLocalWasm(base_wasm, plugin, *configuration, dispatcher));
     });
     // Do not return this WASM VM since this is per-thread. Returning it would indicate that
     // this is a singleton.
-    cb(nullptr);
+    cb(std::make_unique<Server::WasmService>(std::move(tls_slot)));
   };
 
   Common::Wasm::createWasm(config.config().vm_config(), plugin, context.scope(),

--- a/source/extensions/wasm/config.cc
+++ b/source/extensions/wasm/config.cc
@@ -42,8 +42,6 @@ void WasmFactory::createWasm(const envoy::extensions::wasm::v3::WasmService& con
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
           Common::Wasm::getOrCreateThreadLocalWasm(base_wasm, plugin, *configuration, dispatcher));
     });
-    // Do not return this WASM VM since this is per-thread. Returning it would indicate that
-    // this is a singleton.
     cb(std::make_unique<Server::WasmService>(std::move(tls_slot)));
   };
 

--- a/source/extensions/wasm/config.h
+++ b/source/extensions/wasm/config.h
@@ -19,6 +19,7 @@ public:
 
 private:
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;
+  ThreadLocal::SlotPtr tls_slot_;
 };
 
 } // namespace Wasm

--- a/source/extensions/wasm/config.h
+++ b/source/extensions/wasm/config.h
@@ -15,11 +15,10 @@ public:
   std::string name() override { return "envoy.wasm"; }
   void createWasm(const envoy::extensions::wasm::v3::WasmService& config,
                   Server::Configuration::WasmFactoryContext& context,
-                  Server::CreateWasmCallback&& cb) override;
+                  Server::CreateWasmServiceCallback&& cb) override;
 
 private:
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;
-  ThreadLocal::SlotPtr tls_slot_;
 };
 
 } // namespace Wasm

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -16,6 +16,7 @@
 #include "envoy/network/dns.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/options.h"
+#include "envoy/server/wasm_config.h"
 #include "envoy/upstream/cluster_manager.h"
 
 #include "common/api/api_impl.h"
@@ -43,6 +44,7 @@
 #include "server/guarddog_impl.h"
 #include "server/listener_hooks.h"
 #include "server/ssl_context_manager.h"
+#include "server/wasm_config_impl.h"
 
 namespace Envoy {
 namespace Server {
@@ -422,6 +424,28 @@ void InstanceImpl::initialize(const Options& options,
         stats_store_, *ssl_context_manager_, *random_generator_, info_factory_, access_log_manager_,
         *config_.clusterManager(), *local_info_, *admin_, *singleton_manager_, thread_local_,
         messageValidationContext().dynamicValidationVisitor(), *api_);
+  }
+
+  // Optional Wasm services. These must be initialied afer threading but before the main
+  // configuration which many reference wasm vms.
+  if (bootstrap_.wasm_service_size() > 0) {
+    auto factory = Registry::FactoryRegistry<Configuration::WasmFactory>::getFactory("envoy.wasm");
+    if (factory) {
+      for (auto& config : bootstrap_.wasm_service()) {
+        auto scope = Stats::ScopeSharedPtr(stats_store_.createScope(config.stat_prefix()));
+        Configuration::WasmFactoryContextImpl wasm_factory_context(clusterManager(), initManager(),
+                                                                   *dispatcher_, thread_local_,
+                                                                   api(), scope, *local_info_);
+        factory->createWasm(config, wasm_factory_context, [this](WasmSharedPtr wasm) {
+          if (wasm) {
+            // If not nullptr, this is a singleton WASM service.
+            wasm_.emplace_back(std::move(wasm));
+          }
+        });
+      }
+    } else {
+      ENVOY_LOG(warn, "No wasm factory available, so no wasm service started.");
+    }
   }
 
   for (Stats::SinkPtr& sink : config_.statsSinks()) {

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -436,7 +436,7 @@ void InstanceImpl::initialize(const Options& options,
         Configuration::WasmFactoryContextImpl wasm_factory_context(clusterManager(), initManager(),
                                                                    *dispatcher_, thread_local_,
                                                                    api(), scope, *local_info_);
-        factory->createWasm(config, wasm_factory_context, [this](WasmSharedPtr wasm) {
+        factory->createWasm(config, wasm_factory_context, [this](WasmServicePtr wasm) {
           if (wasm) {
             // If not nullptr, this is a singleton WASM service.
             wasm_.emplace_back(std::move(wasm));

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -335,7 +335,7 @@ private:
   Upstream::ProdClusterInfoFactory info_factory_;
   Upstream::HdsDelegatePtr hds_delegate_;
   std::unique_ptr<OverloadManagerImpl> overload_manager_;
-  std::vector<std::shared_ptr<Wasm>> wasm_;
+  std::vector<WasmServicePtr> wasm_;
   Envoy::MutexTracer* mutex_tracer_;
   Grpc::ContextImpl grpc_context_;
   Http::ContextImpl http_context_;

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -53,8 +53,8 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASM) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  Server::WasmSharedPtr wasmptr = nullptr;
-  factory->createWasm(config, context, [&wasmptr](Server::WasmSharedPtr wasm) { wasmptr = wasm; });
+  Server::WasmServicePtr wasmptr = nullptr;
+  factory->createWasm(config, context, [&wasmptr](Server::WasmServicePtr wasm) { wasmptr = std::move(wasm); });
   EXPECT_CALL(init_watcher, ready());
   init_manager.initialize(init_watcher);
   EXPECT_NE(wasmptr, nullptr);
@@ -82,10 +82,12 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASMPerThread) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  factory->createWasm(config, context,
-                      [](Server::WasmSharedPtr wasm) { EXPECT_EQ(wasm, nullptr); });
+  Server::WasmServicePtr wasmptr = nullptr;
+  factory->createWasm(config, context, [&wasmptr](Server::WasmServicePtr wasm) { wasmptr = std::move(wasm); });
   EXPECT_CALL(init_watcher, ready());
   init_manager.initialize(init_watcher);
+  EXPECT_NE(wasmptr, nullptr);
+  wasmptr.reset();
   tls.shutdownThread();
 }
 
@@ -111,7 +113,7 @@ TEST_P(WasmFactoryTest, MissingImport) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  EXPECT_THROW_WITH_REGEX(factory->createWasm(config, context, [](Server::WasmSharedPtr) {});
+  EXPECT_THROW_WITH_REGEX(factory->createWasm(config, context, [](Server::WasmServicePtr) {});
                           , Extensions::Common::Wasm::WasmVmException,
                           "Failed to load WASM module due to a missing import: env.missing");
 }
@@ -137,7 +139,7 @@ TEST_P(WasmFactoryTest, UnspecifiedRuntime) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context, [](Server::WasmSharedPtr) {}),
+  EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context, [](Server::WasmServicePtr) {}),
                             Extensions::Common::Wasm::WasmVmException,
                             "Failed to create WASM VM with unspecified runtime.");
 }
@@ -163,7 +165,7 @@ TEST_P(WasmFactoryTest, UnknownRuntime) {
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
-  EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context, [](Server::WasmSharedPtr) {}),
+  EXPECT_THROW_WITH_MESSAGE(factory->createWasm(config, context, [](Server::WasmServicePtr) {}),
                             Extensions::Common::Wasm::WasmVmException,
                             "Failed to create WASM VM using envoy.wasm.runtime.invalid runtime. "
                             "Envoy was compiled without support for it.");

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -54,7 +54,8 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASM) {
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
   Server::WasmServicePtr wasmptr = nullptr;
-  factory->createWasm(config, context, [&wasmptr](Server::WasmServicePtr wasm) { wasmptr = std::move(wasm); });
+  factory->createWasm(config, context,
+                      [&wasmptr](Server::WasmServicePtr wasm) { wasmptr = std::move(wasm); });
   EXPECT_CALL(init_watcher, ready());
   init_manager.initialize(init_watcher);
   EXPECT_NE(wasmptr, nullptr);
@@ -83,7 +84,8 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASMPerThread) {
   Server::Configuration::WasmFactoryContextImpl context(cluster_manager, init_manager, dispatcher,
                                                         tls, *api, scope, local_info);
   Server::WasmServicePtr wasmptr = nullptr;
-  factory->createWasm(config, context, [&wasmptr](Server::WasmServicePtr wasm) { wasmptr = std::move(wasm); });
+  factory->createWasm(config, context,
+                      [&wasmptr](Server::WasmServicePtr wasm) { wasmptr = std::move(wasm); });
   EXPECT_CALL(init_watcher, ready());
   init_manager.initialize(init_watcher);
   EXPECT_NE(wasmptr, nullptr);

--- a/test/extensions/wasm/config_test.cc
+++ b/test/extensions/wasm/config_test.cc
@@ -86,6 +86,7 @@ TEST_P(WasmFactoryTest, CreateWasmFromWASMPerThread) {
                       [](Server::WasmSharedPtr wasm) { EXPECT_EQ(wasm, nullptr); });
   EXPECT_CALL(init_watcher, ready());
   init_manager.initialize(init_watcher);
+  tls.shutdownThread();
 }
 
 TEST_P(WasmFactoryTest, MissingImport) {


### PR DESCRIPTION
This change restores Wasm Service, which was accidentally removed
in a bad merge (#321).

It also fixes a number of issuses:

1. Wasm Services were started before Cluster Manager was initialized,
   which crashed Envoy when Wasm Service tried to dispatch a callout.

2. Wasm Services (per-thread) were not stored and they were getting
   out of scope, so they were immediately destroyed.

3. Wasm Services (singleton) were started twice.

Signed-off-by: Piotr Sikora <piotrsikora@google.com>