### PR TITLE
Add  getContext in null_plugin

### DIFF
--- a/source/extensions/common/wasm/null/null_plugin.cc
+++ b/source/extensions/common/wasm/null/null_plugin.cc
@@ -473,6 +473,11 @@ Plugin::RootContext* nullVmGetRoot(absl::string_view root_id) {
   return static_cast<NullPlugin*>(null_vm->plugin_.get())->getRoot(root_id);
 }
 
+Plugin::Context* nullVmGetContext(uint32_t context_id) {
+  auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
+  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
+}
+
 } // namespace Null
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/common/wasm/null/null_plugin.h
+++ b/source/extensions/common/wasm/null/null_plugin.h
@@ -112,11 +112,11 @@ public:
   void onDelete(uint64_t context_id);
 
   Plugin::RootContext* getRoot(absl::string_view root_id);
+  Plugin::Context* getContext(uint64_t context_id);
 
 private:
   Plugin::Context* ensureContext(uint64_t context_id, uint64_t root_context_id);
   Plugin::RootContext* ensureRootContext(uint64_t context_id);
-  Plugin::Context* getContext(uint64_t context_id);
   Plugin::RootContext* getRootContext(uint64_t context_id);
   Plugin::ContextBase* getContextBase(uint64_t context_id);
 

--- a/source/extensions/common/wasm/null/wasm_api_impl.h
+++ b/source/extensions/common/wasm/null/wasm_api_impl.h
@@ -10,9 +10,11 @@ extern thread_local Envoy::Extensions::Common::Wasm::Context* current_context_;
 namespace Null {
 namespace Plugin {
 class RootContext;
-}
+class Context;
+} // namespace Plugin
 
 Plugin::RootContext* nullVmGetRoot(absl::string_view root_id);
+Plugin::Context* nullVmGetContext(uint32_t context_id);
 
 namespace Plugin {
 
@@ -249,6 +251,7 @@ inline WasmResult proxy_call_foreign_function(const char* function_name, size_t 
 #undef WR
 
 inline RootContext* getRoot(StringView root_id) { return nullVmGetRoot(root_id); }
+inline Plugin::Context* getContext(uint32_t context_id) { return nullVmGetContext(context_id); }
 
 } // namespace Plugin
 } // namespace Null


### PR DESCRIPTION
This is submitting JohnPlevyak's work: https://github.com/envoyproxy/envoy-wasm/compare/master...jplevyak:get_context?expand=1

Signed-off-by: gargnupur <gargnupur@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Add  getContext in null_plugin
Risk Level: Low
Testing: Tested with istio/proxy
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
