### PR TITLE
Add getContextBase() and getRootContext() function to the Null Vm.

### DIFF
--- a/source/extensions/common/wasm/null/null_plugin.cc
+++ b/source/extensions/common/wasm/null/null_plugin.cc
@@ -478,19 +478,14 @@ Plugin::Context* nullVmGetContext(uint32_t context_id) {
   return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
 }
 
-Plugin::Context* nullVmGetContext(uint32_t context_id) {
+Plugin::RootContext* nullVmGetRootContext(uint32_t context_id) {
   auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
-  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
+  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getRootContext(context_id);
 }
 
 Plugin::ContextBase* nullVmGetContextBase(uint32_t context_id) {
   auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
-  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
-}
-
-Plugin::ContextBase* nullVmGetContext(uint32_t context_id) {
-  auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
-  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
+  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContextBase(context_id);
 }
 
 } // namespace Null

--- a/source/extensions/common/wasm/null/null_plugin.cc
+++ b/source/extensions/common/wasm/null/null_plugin.cc
@@ -478,6 +478,21 @@ Plugin::Context* nullVmGetContext(uint32_t context_id) {
   return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
 }
 
+Plugin::Context* nullVmGetContext(uint32_t context_id) {
+  auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
+  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
+}
+
+Plugin::ContextBase* nullVmGetContextBase(uint32_t context_id) {
+  auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
+  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
+}
+
+Plugin::ContextBase* nullVmGetContext(uint32_t context_id) {
+  auto null_vm = static_cast<NullVm*>(current_context_->wasmVm());
+  return static_cast<NullPlugin*>(null_vm->plugin_.get())->getContext(context_id);
+}
+
 } // namespace Null
 } // namespace Wasm
 } // namespace Common

--- a/source/extensions/common/wasm/null/null_plugin.h
+++ b/source/extensions/common/wasm/null/null_plugin.h
@@ -113,12 +113,12 @@ public:
 
   Plugin::RootContext* getRoot(absl::string_view root_id);
   Plugin::Context* getContext(uint64_t context_id);
+  Plugin::RootContext* getRootContext(uint64_t context_id);
+  Plugin::ContextBase* getContextBase(uint64_t context_id);
 
 private:
   Plugin::Context* ensureContext(uint64_t context_id, uint64_t root_context_id);
   Plugin::RootContext* ensureRootContext(uint64_t context_id);
-  Plugin::RootContext* getRootContext(uint64_t context_id);
-  Plugin::ContextBase* getContextBase(uint64_t context_id);
 
   NullPluginRegistry* registry_{};
   std::unordered_map<std::string, Plugin::RootContext*> root_context_map_;

--- a/source/extensions/common/wasm/null/wasm_api_impl.h
+++ b/source/extensions/common/wasm/null/wasm_api_impl.h
@@ -11,10 +11,13 @@ namespace Null {
 namespace Plugin {
 class RootContext;
 class Context;
+class ContextBase;
 } // namespace Plugin
 
 Plugin::RootContext* nullVmGetRoot(absl::string_view root_id);
 Plugin::Context* nullVmGetContext(uint32_t context_id);
+Plugin::RooContext* nullVmGetRootContext(uint32_t context_id);
+Plugin::ContextBase* nullVmGetContextBase(uint32_t context_id);
 
 namespace Plugin {
 
@@ -258,6 +261,12 @@ inline WasmResult proxy_call_foreign_function(const char* function_name, size_t 
 
 inline RootContext* getRoot(StringView root_id) { return nullVmGetRoot(root_id); }
 inline Plugin::Context* getContext(uint32_t context_id) { return nullVmGetContext(context_id); }
+inline Plugin::RootContext* getRootContext(uint32_t context_id) {
+  return nullVmGetRootContext(context_id);
+}
+inline Plugin::ContextBase* getContextBase(uint32_t context_id) {
+  return nullVmGetContextBase(context_id);
+}
 
 } // namespace Plugin
 } // namespace Null

--- a/source/extensions/common/wasm/null/wasm_api_impl.h
+++ b/source/extensions/common/wasm/null/wasm_api_impl.h
@@ -16,7 +16,7 @@ class ContextBase;
 
 Plugin::RootContext* nullVmGetRoot(absl::string_view root_id);
 Plugin::Context* nullVmGetContext(uint32_t context_id);
-Plugin::RooContext* nullVmGetRootContext(uint32_t context_id);
+Plugin::RootContext* nullVmGetRootContext(uint32_t context_id);
 Plugin::ContextBase* nullVmGetContextBase(uint32_t context_id);
 
 namespace Plugin {


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>
