### PR TITLE
Fix http call response crash

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1737,7 +1737,8 @@ void Context::setEncoderFilterCallbacks(Envoy::Http::StreamEncoderFilterCallback
 
 void Context::onHttpCallSuccess(uint32_t token, Envoy::Http::ResponseMessagePtr& response) {
   http_call_response_ = &response;
-  onHttpCallResponse(token, response->headers().size(), response->body()->length(),
+  uint32_t body_size = response->body() ? response->body()->length() : 0;
+  onHttpCallResponse(token, response->headers().size(), body_size,
                      headerSize(response->trailers()));
   http_call_response_ = nullptr;
   http_request_.erase(token);


### PR DESCRIPTION
Empty body will cause a crash in onHttpCallSuccess.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
