### PR TITLE
Use ClusterInfo from streaminfo to get clustername too

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -516,6 +516,9 @@ Context::FindValue(absl::string_view name, Protobuf::Arena* arena) const {
       return CelValue::CreateString(&info->upstreamHost()->cluster().name());
     } else if (info && info->routeEntry()) {
       return CelValue::CreateString(&info->routeEntry()->clusterName());
+    } else if (info && info->upstreamClusterInfo().has_value() &&
+               info->upstreamClusterInfo().value()) {
+      return CelValue::CreateString(&info->upstreamClusterInfo().value()->name());
     }
     break;
   case PropertyToken::CLUSTER_METADATA:


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

Description: Use ClusterInfo from streaminfo to get clustername too
Ref: https://github.com/istio/istio/issues/21566
This will help get name of the blackhole cluster
 
This depends on PR: https://github.com/envoyproxy/envoy-wasm/pull/460, but separating into a separate PR, so that this is easy to cherry-pick to istio/envoy 1.5 release.