### PR TITLE
Move to use proxy-wasm-cpp-sdk for the envoy code.

### DIFF
--- a/bazel/external/proxy_wasm_cpp_host.BUILD
+++ b/bazel/external/proxy_wasm_cpp_host.BUILD
@@ -1,0 +1,54 @@
+licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "include",
+    hdrs = [
+        "include/proxy-wasm/compat.h",
+        "include/proxy-wasm/context.h",
+        "include/proxy-wasm/exports.h",
+        "include/proxy-wasm/null.h",
+        "include/proxy-wasm/null_plugin.h",
+        "include/proxy-wasm/null_vm.h",
+        "include/proxy-wasm/null_vm_plugin.h",
+        "include/proxy-wasm/v8.h",
+        "include/proxy-wasm/wasm.h",
+        "include/proxy-wasm/wasm_api_impl.h",
+        "include/proxy-wasm/wasm_vm.h",
+        "include/proxy-wasm/word.h",
+    ],
+    copts = ["-std=c++14"],
+    deps = [
+        "@proxy_wasm_cpp_sdk//:common_lib",
+    ],
+)
+
+cc_library(
+    name = "lib",
+    srcs = [
+        "src/base64.cc",
+        "src/base64.h",
+        "src/context.cc",
+        "src/exports.cc",
+        "src/foreign.cc",
+        "src/null/null.cc",
+        "src/null/null_plugin.cc",
+        "src/null/null_vm.cc",
+        "src/v8/v8.cc",
+        "src/wasm.cc",
+    ],
+    copts = ["-std=c++14"],
+    deps = [
+        ":include",
+        "//external:abseil_flat_hash_map",
+        "//external:abseil_optional",
+        "//external:abseil_strings",
+        "//external:protobuf",
+        "//external:wee8",
+        "//external:zlib",
+        "@boringssl//:ssl",
+        "@proxy_wasm_cpp_sdk//:api_lib",
+        "@proxy_wasm_cpp_sdk//:common_lib",
+    ],
+)

--- a/bazel/external/proxy_wasm_cpp_sdk.BUILD
+++ b/bazel/external/proxy_wasm_cpp_sdk.BUILD
@@ -1,0 +1,16 @@
+licenses(["notice"])  # Apache 2
+
+package(default_visibility = ["//visibility:public"])
+
+cc_library(
+    name = "api_lib",
+    hdrs = ["proxy_wasm_api.h"],
+)
+
+cc_library(
+    name = "common_lib",
+    hdrs = [
+        "proxy_wasm_common.h",
+        "proxy_wasm_enums.h",
+    ],
+)

--- a/bazel/repositories.bzl
+++ b/bazel/repositories.bzl
@@ -149,6 +149,8 @@ def envoy_dependencies(skip_targets = []):
     _io_opentracing_cpp()
     _net_zlib()
     _upb()
+    _proxy_wasm_cpp_sdk()
+    _proxy_wasm_cpp_host()
     _repository_impl("com_googlesource_code_re2")
     _com_google_cel_cpp()
     _repository_impl("bazel_toolchains")
@@ -730,6 +732,18 @@ def _upb():
     native.bind(
         name = "upb_lib",
         actual = "@upb//:upb",
+    )
+
+def _proxy_wasm_cpp_sdk():
+    _repository_impl(
+        name = "proxy_wasm_cpp_sdk",
+        build_file = "@envoy//bazel/external:proxy_wasm_cpp_sdk.BUILD",
+    )
+
+def _proxy_wasm_cpp_host():
+    _repository_impl(
+        name = "proxy_wasm_cpp_host",
+        build_file = "@envoy//bazel/external:proxy_wasm_cpp_host.BUILD",
     )
 
 def _com_github_google_jwt_verify():

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -335,4 +335,14 @@ REPOSITORY_LOCATIONS = dict(
         strip_prefix = "kafka-python-2.0.0",
         urls = ["https://github.com/dpkp/kafka-python/archive/2.0.0.tar.gz"],
     ),
+    proxy_wasm_cpp_sdk = dict(
+        sha256 = "c3057c7980f345669d03206e83e0b41ac315e24d6a3591893311375f4e1ee828",
+        strip_prefix = "proxy-wasm-cpp-sdk-361eb06fa52deced724b68aea4563082ef8d52d1",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/361eb06fa52deced724b68aea4563082ef8d52d1.tar.gz"],
+    ),
+    proxy_wasm_cpp_host = dict(
+        sha256 = "4aaf28e2c3326f9f465ffc460162ee195ee3ceaba93241c58453ae57373191fe",
+        strip_prefix = "proxy-wasm-cpp-host-a9c0c47d8062aa36d955b8604b1b96ee9078253f",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/a9c0c47d8062aa36d955b8604b1b96ee9078253f.tar.gz"],
+    ),
 )

--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -71,6 +71,8 @@ envoy_cc_library(
         "//source/extensions/filters/http:well_known_names",
         "@com_google_cel_cpp//eval/public:activation",
         "@envoy_api//envoy/extensions/wasm/v3:pkg_cc_proto",
+        "@proxy_wasm_cpp_host//:include",
+        "@proxy_wasm_cpp_sdk//:common_lib",
     ],
 )
 
@@ -100,7 +102,6 @@ envoy_cc_library(
         ":wasm_hdr",
         ":wasm_interoperation_lib",
         ":wasm_vm_lib",
-        "//api/wasm/cpp:common_lib",
         "//external:abseil_base",
         "//external:abseil_node_hash_map",
         "//source/common/buffer:buffer_lib",

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -654,55 +654,55 @@ WasmResult Context::enqueueSharedQueue(uint32_t token, absl::string_view value) 
 }
 
 // Header/Trailer/Metadata Maps.
-Http::HeaderMap* Context::getMap(HeaderMapType type) {
+Http::HeaderMap* Context::getMap(WasmHeaderMapType type) {
   switch (type) {
-  case HeaderMapType::RequestHeaders:
+  case WasmHeaderMapType::RequestHeaders:
     return request_headers_;
-  case HeaderMapType::RequestTrailers:
+  case WasmHeaderMapType::RequestTrailers:
     return request_trailers_;
-  case HeaderMapType::ResponseHeaders:
+  case WasmHeaderMapType::ResponseHeaders:
     return response_headers_;
-  case HeaderMapType::ResponseTrailers:
+  case WasmHeaderMapType::ResponseTrailers:
     return response_trailers_;
   default:
     return nullptr;
   }
 }
 
-const Http::HeaderMap* Context::getConstMap(HeaderMapType type) {
+const Http::HeaderMap* Context::getConstMap(WasmHeaderMapType type) {
   switch (type) {
-  case HeaderMapType::RequestHeaders:
+  case WasmHeaderMapType::RequestHeaders:
     if (access_log_request_headers_) {
       return access_log_request_headers_;
     }
     return request_headers_;
-  case HeaderMapType::RequestTrailers:
+  case WasmHeaderMapType::RequestTrailers:
     if (access_log_request_trailers_) {
       return access_log_request_trailers_;
     }
     return request_trailers_;
-  case HeaderMapType::ResponseHeaders:
+  case WasmHeaderMapType::ResponseHeaders:
     if (access_log_response_headers_) {
       return access_log_response_headers_;
     }
     return response_headers_;
-  case HeaderMapType::ResponseTrailers:
+  case WasmHeaderMapType::ResponseTrailers:
     if (access_log_response_trailers_) {
       return access_log_response_trailers_;
     }
     return response_trailers_;
-  case HeaderMapType::GrpcReceiveInitialMetadata:
+  case WasmHeaderMapType::GrpcReceiveInitialMetadata:
     return rootContext()->grpc_receive_initial_metadata_.get();
-  case HeaderMapType::GrpcReceiveTrailingMetadata:
+  case WasmHeaderMapType::GrpcReceiveTrailingMetadata:
     return rootContext()->grpc_receive_trailing_metadata_.get();
-  case HeaderMapType::HttpCallResponseHeaders: {
+  case WasmHeaderMapType::HttpCallResponseHeaders: {
     Envoy::Http::ResponseMessagePtr* response = rootContext()->http_call_response_;
     if (response) {
       return &(*response)->headers();
     }
     return nullptr;
   }
-  case HeaderMapType::HttpCallResponseTrailers: {
+  case WasmHeaderMapType::HttpCallResponseTrailers: {
     Envoy::Http::ResponseMessagePtr* response = rootContext()->http_call_response_;
     if (response) {
       return (*response)->trailers();
@@ -713,7 +713,7 @@ const Http::HeaderMap* Context::getConstMap(HeaderMapType type) {
   return nullptr;
 }
 
-void Context::addHeaderMapValue(HeaderMapType type, absl::string_view key,
+void Context::addHeaderMapValue(WasmHeaderMapType type, absl::string_view key,
                                 absl::string_view value) {
   auto map = getMap(type);
   if (!map) {
@@ -723,7 +723,7 @@ void Context::addHeaderMapValue(HeaderMapType type, absl::string_view key,
   map->addCopy(lower_key, std::string(value));
 }
 
-absl::string_view Context::getHeaderMapValue(HeaderMapType type, absl::string_view key) {
+absl::string_view Context::getHeaderMapValue(WasmHeaderMapType type, absl::string_view key) {
   auto map = getConstMap(type);
   if (!map) {
     return "";
@@ -753,9 +753,11 @@ Pairs headerMapToPairs(const Http::HeaderMap* map) {
   return pairs;
 }
 
-Pairs Context::getHeaderMapPairs(HeaderMapType type) { return headerMapToPairs(getConstMap(type)); }
+Pairs Context::getHeaderMapPairs(WasmHeaderMapType type) {
+  return headerMapToPairs(getConstMap(type));
+}
 
-void Context::setHeaderMapPairs(HeaderMapType type, const Pairs& pairs) {
+void Context::setHeaderMapPairs(WasmHeaderMapType type, const Pairs& pairs) {
   auto map = getMap(type);
   if (!map) {
     return;
@@ -778,7 +780,7 @@ void Context::setHeaderMapPairs(HeaderMapType type, const Pairs& pairs) {
   }
 }
 
-void Context::removeHeaderMapValue(HeaderMapType type, absl::string_view key) {
+void Context::removeHeaderMapValue(WasmHeaderMapType type, absl::string_view key) {
   auto map = getMap(type);
   if (!map) {
     return;
@@ -787,7 +789,7 @@ void Context::removeHeaderMapValue(HeaderMapType type, absl::string_view key) {
   map->remove(lower_key);
 }
 
-void Context::replaceHeaderMapValue(HeaderMapType type, absl::string_view key,
+void Context::replaceHeaderMapValue(WasmHeaderMapType type, absl::string_view key,
                                     absl::string_view value) {
   auto map = getMap(type);
   if (!map) {
@@ -797,7 +799,7 @@ void Context::replaceHeaderMapValue(HeaderMapType type, absl::string_view key,
   map->setCopy(lower_key, value);
 }
 
-uint32_t Context::getHeaderMapSize(HeaderMapType type) {
+uint32_t Context::getHeaderMapSize(WasmHeaderMapType type) {
   auto map = getMap(type);
   if (!map) {
     return 0;
@@ -807,29 +809,29 @@ uint32_t Context::getHeaderMapSize(HeaderMapType type) {
 
 // Buffer
 
-const Buffer::Instance* Context::getBuffer(BufferType type) {
+const Buffer::Instance* Context::getBuffer(WasmBufferType type) {
   switch (type) {
-  case BufferType::HttpRequestBody:
+  case WasmBufferType::HttpRequestBody:
     if (buffering_request_body_) {
       return decoder_callbacks_->decodingBuffer();
     }
     return request_body_buffer_;
-  case BufferType::HttpResponseBody:
+  case WasmBufferType::HttpResponseBody:
     if (buffering_response_body_) {
       return encoder_callbacks_->encodingBuffer();
     }
     return response_body_buffer_;
-  case BufferType::NetworkDownstreamData:
+  case WasmBufferType::NetworkDownstreamData:
     return network_downstream_data_buffer_;
-  case BufferType::NetworkUpstreamData:
+  case WasmBufferType::NetworkUpstreamData:
     return network_upstream_data_buffer_;
-  case BufferType::HttpCallResponseBody: {
+  case WasmBufferType::HttpCallResponseBody: {
     Envoy::Http::ResponseMessagePtr* response = rootContext()->http_call_response_;
     if (response) {
       return (*response)->body().get();
     }
   } break;
-  case BufferType::GrpcReceiveBuffer:
+  case WasmBufferType::GrpcReceiveBuffer:
     return rootContext()->grpc_receive_buffer_.get();
   default:
     break;
@@ -837,26 +839,27 @@ const Buffer::Instance* Context::getBuffer(BufferType type) {
   return nullptr;
 }
 
-WasmResult Context::setBuffer(BufferType type, std::function<void(Buffer::Instance&)> callback) {
+WasmResult Context::setBuffer(WasmBufferType type,
+                              std::function<void(Buffer::Instance&)> callback) {
   switch (type) {
-  case BufferType::HttpRequestBody:
+  case WasmBufferType::HttpRequestBody:
     if (buffering_request_body_) {
       decoder_callbacks_->modifyDecodingBuffer(callback);
     } else {
       callback(*request_body_buffer_);
     }
     return WasmResult::Ok;
-  case BufferType::HttpResponseBody:
+  case WasmBufferType::HttpResponseBody:
     if (buffering_response_body_) {
       encoder_callbacks_->modifyEncodingBuffer(callback);
     } else {
       callback(*response_body_buffer_);
     }
     return WasmResult::Ok;
-  case BufferType::NetworkDownstreamData:
+  case WasmBufferType::NetworkDownstreamData:
     callback(*network_downstream_data_buffer_);
     return WasmResult::Ok;
-  case BufferType::NetworkUpstreamData:
+  case WasmBufferType::NetworkUpstreamData:
     callback(*network_upstream_data_buffer_);
     return WasmResult::Ok;
   default:
@@ -1259,7 +1262,7 @@ Http::FilterDataStatus Context::onRequestBody(bool end_of_stream) {
     return Http::FilterDataStatus::Continue;
   }
   DeferAfterCallActions actions(this);
-  const auto buffer = getBuffer(BufferType::HttpRequestBody);
+  const auto buffer = getBuffer(WasmBufferType::HttpRequestBody);
   const auto buffer_length = (buffer == nullptr) ? 0 : buffer->length();
   switch (wasm_
               ->on_request_body_(this, id_, static_cast<uint32_t>(buffer_length),
@@ -1326,7 +1329,7 @@ Http::FilterDataStatus Context::onResponseBody(bool end_of_stream) {
     return Http::FilterDataStatus::Continue;
   }
   DeferAfterCallActions actions(this);
-  const auto buffer = getBuffer(BufferType::HttpResponseBody);
+  const auto buffer = getBuffer(WasmBufferType::HttpResponseBody);
   const auto buffer_length = (buffer == nullptr) ? 0 : buffer->length();
   switch (wasm_
               ->on_response_body_(this, id_, static_cast<uint32_t>(buffer_length),

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -22,7 +22,7 @@ namespace Extensions {
 namespace Common {
 namespace Wasm {
 
-#include "api/wasm/cpp/proxy_wasm_common.h"
+#include "proxy_wasm_common.h"
 
 class Wasm;
 class WasmVm;
@@ -250,21 +250,22 @@ public:
   virtual WasmResult enqueueSharedQueue(uint32_t token, absl::string_view value);
 
   // Header/Trailer/Metadata Maps
-  virtual void addHeaderMapValue(HeaderMapType type, absl::string_view key,
+  virtual void addHeaderMapValue(WasmHeaderMapType type, absl::string_view key,
                                  absl::string_view value);
-  virtual absl::string_view getHeaderMapValue(HeaderMapType type, absl::string_view key);
-  virtual Pairs getHeaderMapPairs(HeaderMapType type);
-  virtual void setHeaderMapPairs(HeaderMapType type, const Pairs& pairs);
+  virtual absl::string_view getHeaderMapValue(WasmHeaderMapType type, absl::string_view key);
+  virtual Pairs getHeaderMapPairs(WasmHeaderMapType type);
+  virtual void setHeaderMapPairs(WasmHeaderMapType type, const Pairs& pairs);
 
-  virtual void removeHeaderMapValue(HeaderMapType type, absl::string_view key);
-  virtual void replaceHeaderMapValue(HeaderMapType type, absl::string_view key,
+  virtual void removeHeaderMapValue(WasmHeaderMapType type, absl::string_view key);
+  virtual void replaceHeaderMapValue(WasmHeaderMapType type, absl::string_view key,
                                      absl::string_view value);
 
-  virtual uint32_t getHeaderMapSize(HeaderMapType type);
+  virtual uint32_t getHeaderMapSize(WasmHeaderMapType type);
 
   // Buffer
-  virtual const Buffer::Instance* getBuffer(BufferType type);
-  virtual WasmResult setBuffer(BufferType type, std::function<void(Buffer::Instance&)> callback);
+  virtual const Buffer::Instance* getBuffer(WasmBufferType type);
+  virtual WasmResult setBuffer(WasmBufferType type,
+                               std::function<void(Buffer::Instance&)> callback);
   bool end_of_stream() { return end_of_stream_; }
 
   // HTTP
@@ -407,8 +408,8 @@ protected:
   bool IsGrpcStreamToken(uint32_t token) { return (token & 1) == 0; }
   bool IsGrpcCallToken(uint32_t token) { return (token & 1) == 1; }
 
-  Http::HeaderMap* getMap(HeaderMapType type);
-  const Http::HeaderMap* getConstMap(HeaderMapType type);
+  Http::HeaderMap* getMap(WasmHeaderMapType type);
+  const Http::HeaderMap* getConstMap(WasmHeaderMapType type);
 
   Wasm* wasm_{nullptr};
   uint32_t id_{0};

--- a/source/extensions/common/wasm/exports.cc
+++ b/source/extensions/common/wasm/exports.cc
@@ -352,7 +352,7 @@ Word enqueue_shared_queue(void* raw_context, Word token, Word data_ptr, Word dat
 // Header/Trailer/Metadata Maps
 Word add_header_map_value(void* raw_context, Word type, Word key_ptr, Word key_size, Word value_ptr,
                           Word value_size) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
@@ -361,13 +361,13 @@ Word add_header_map_value(void* raw_context, Word type, Word key_ptr, Word key_s
   if (!key || !value) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
-  context->addHeaderMapValue(static_cast<HeaderMapType>(type.u64_), key.value(), value.value());
+  context->addHeaderMapValue(static_cast<WasmHeaderMapType>(type.u64_), key.value(), value.value());
   return wasmResultToWord(WasmResult::Ok);
 }
 
 Word get_header_map_value(void* raw_context, Word type, Word key_ptr, Word key_size,
                           Word value_ptr_ptr, Word value_size_ptr) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
@@ -375,14 +375,14 @@ Word get_header_map_value(void* raw_context, Word type, Word key_ptr, Word key_s
   if (!key) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
-  auto result = context->getHeaderMapValue(static_cast<HeaderMapType>(type.u64_), key.value());
+  auto result = context->getHeaderMapValue(static_cast<WasmHeaderMapType>(type.u64_), key.value());
   context->wasm()->copyToPointerSize(result, value_ptr_ptr.u64_, value_size_ptr.u64_);
   return wasmResultToWord(WasmResult::Ok);
 }
 
 Word replace_header_map_value(void* raw_context, Word type, Word key_ptr, Word key_size,
                               Word value_ptr, Word value_size) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
@@ -391,12 +391,13 @@ Word replace_header_map_value(void* raw_context, Word type, Word key_ptr, Word k
   if (!key || !value) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
-  context->replaceHeaderMapValue(static_cast<HeaderMapType>(type.u64_), key.value(), value.value());
+  context->replaceHeaderMapValue(static_cast<WasmHeaderMapType>(type.u64_), key.value(),
+                                 value.value());
   return wasmResultToWord(WasmResult::Ok);
 }
 
 Word remove_header_map_value(void* raw_context, Word type, Word key_ptr, Word key_size) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
@@ -404,16 +405,16 @@ Word remove_header_map_value(void* raw_context, Word type, Word key_ptr, Word ke
   if (!key) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
-  context->removeHeaderMapValue(static_cast<HeaderMapType>(type.u64_), key.value());
+  context->removeHeaderMapValue(static_cast<WasmHeaderMapType>(type.u64_), key.value());
   return wasmResultToWord(WasmResult::Ok);
 }
 
 Word get_header_map_pairs(void* raw_context, Word type, Word ptr_ptr, Word size_ptr) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
-  auto result = context->getHeaderMapPairs(static_cast<HeaderMapType>(type.u64_));
+  auto result = context->getHeaderMapPairs(static_cast<WasmHeaderMapType>(type.u64_));
   if (!getPairs(context, result, ptr_ptr.u64_, size_ptr.u64_)) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
@@ -421,7 +422,7 @@ Word get_header_map_pairs(void* raw_context, Word type, Word ptr_ptr, Word size_
 }
 
 Word set_header_map_pairs(void* raw_context, Word type, Word ptr, Word size) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
@@ -429,16 +430,16 @@ Word set_header_map_pairs(void* raw_context, Word type, Word ptr, Word size) {
   if (!data) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
-  context->setHeaderMapPairs(static_cast<HeaderMapType>(type.u64_), toPairs(data.value()));
+  context->setHeaderMapPairs(static_cast<WasmHeaderMapType>(type.u64_), toPairs(data.value()));
   return wasmResultToWord(WasmResult::Ok);
 }
 
 Word get_header_map_size(void* raw_context, Word type, Word result_ptr) {
-  if (type.u64_ > static_cast<uint64_t>(HeaderMapType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmHeaderMapType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
-  size_t result = context->getHeaderMapSize(static_cast<HeaderMapType>(type.u64_));
+  size_t result = context->getHeaderMapSize(static_cast<WasmHeaderMapType>(type.u64_));
   if (!context->wasmVm()->setWord(result_ptr.u64_, Word(result))) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
@@ -448,11 +449,11 @@ Word get_header_map_size(void* raw_context, Word type, Word result_ptr) {
 // Buffer
 Word get_buffer_bytes(void* raw_context, Word type, Word start, Word length, Word ptr_ptr,
                       Word size_ptr) {
-  if (type.u64_ > static_cast<uint64_t>(BufferType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmBufferType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
-  auto buffer = context->getBuffer(static_cast<BufferType>(type.u64_));
+  auto buffer = context->getBuffer(static_cast<WasmBufferType>(type.u64_));
   if (!buffer) {
     return wasmResultToWord(WasmResult::NotFound);
   }
@@ -480,16 +481,17 @@ Word get_buffer_bytes(void* raw_context, Word type, Word start, Word length, Wor
 }
 
 Word get_buffer_status(void* raw_context, Word type, Word length_ptr, Word flags_ptr) {
-  if (type.u64_ > static_cast<uint64_t>(BufferType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmBufferType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
-  auto buffer = context->getBuffer(static_cast<BufferType>(type.u64_));
+  auto buffer = context->getBuffer(static_cast<WasmBufferType>(type.u64_));
   if (!buffer) {
     return wasmResultToWord(WasmResult::NotFound);
   }
   auto length = buffer->length();
-  uint32_t flags = context->end_of_stream() ? static_cast<uint32_t>(BufferFlags::EndOfStream) : 0;
+  uint32_t flags =
+      context->end_of_stream() ? static_cast<uint32_t>(WasmBufferFlags::EndOfStream) : 0;
   if (!context->wasmVm()->setWord(length_ptr.u64_, Word(length))) {
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
@@ -501,11 +503,11 @@ Word get_buffer_status(void* raw_context, Word type, Word length_ptr, Word flags
 
 Word set_buffer_bytes(void* raw_context, Word type, Word start, Word length, Word data_ptr,
                       Word data_size) {
-  if (type.u64_ > static_cast<uint64_t>(BufferType::MAX)) {
+  if (type.u64_ > static_cast<uint64_t>(WasmBufferType::MAX)) {
     return wasmResultToWord(WasmResult::BadArgument);
   }
   auto context = WASM_CONTEXT(raw_context);
-  auto buffer = context->getBuffer(static_cast<BufferType>(type.u64_));
+  auto buffer = context->getBuffer(static_cast<WasmBufferType>(type.u64_));
   if (!buffer) {
     return wasmResultToWord(WasmResult::NotFound);
   }
@@ -514,7 +516,7 @@ Word set_buffer_bytes(void* raw_context, Word type, Word start, Word length, Wor
     return wasmResultToWord(WasmResult::InvalidMemoryAccess);
   }
   WasmResult result = WasmResult::InternalFailure;
-  if (context->setBuffer(static_cast<BufferType>(type.u64_),
+  if (context->setBuffer(static_cast<WasmBufferType>(type.u64_),
                          [start = start.u64_, length = length.u64_, data, &result](auto& buffer) {
                            if (start == 0) {
                              if (length == 0) {

--- a/source/extensions/common/wasm/null/BUILD
+++ b/source/extensions/common/wasm/null/BUILD
@@ -58,13 +58,12 @@ envoy_cc_library(
     deps = [
         ":null_lib",
         ":null_vm_plugin_interface",
-        "//api/wasm/cpp:api_lib",
-        "//api/wasm/cpp:common_lib",
         "//external:abseil_base",
         "//external:abseil_node_hash_map",
         "//source/common/common:assert_lib",
         "//source/common/protobuf",
         "//source/extensions/common/wasm:wasm_hdr",
         "//source/extensions/common/wasm:well_known_names",
+        "@proxy_wasm_cpp_sdk//:api_lib",
     ],
 )

--- a/source/extensions/common/wasm/null/null_plugin.h
+++ b/source/extensions/common/wasm/null/null_plugin.h
@@ -38,7 +38,7 @@ namespace Common {
 namespace Wasm {
 namespace Null {
 namespace Plugin {
-#include "api/wasm/cpp/proxy_wasm_api.h"
+#include "proxy_wasm_api.h"
 } // namespace Plugin
 
 /**

--- a/source/extensions/common/wasm/null/sample_plugin/plugin.cc
+++ b/source/extensions/common/wasm/null/sample_plugin/plugin.cc
@@ -49,7 +49,7 @@ FilterHeadersStatus PluginContext::onRequestHeaders(uint32_t) {
 }
 
 FilterDataStatus PluginContext::onRequestBody(size_t body_buffer_length, bool /* end_of_stream */) {
-  auto body = getBufferBytes(BufferType::HttpRequestBody, 0, body_buffer_length);
+  auto body = getBufferBytes(WasmBufferType::HttpRequestBody, 0, body_buffer_length);
   logError(std::string("onRequestBody ") + std::string(body->view()));
   return FilterDataStatus::Continue;
 }

--- a/source/extensions/common/wasm/null/wasm_api_impl.h
+++ b/source/extensions/common/wasm/null/wasm_api_impl.h
@@ -128,57 +128,58 @@ inline WasmResult proxy_enqueue_shared_queue(uint32_t token, const char* data_pt
 }
 
 // Buffer
-inline WasmResult proxy_get_buffer_bytes(BufferType type, uint64_t start, uint64_t length,
+inline WasmResult proxy_get_buffer_bytes(WasmBufferType type, uint64_t start, uint64_t length,
                                          const char** ptr, size_t* size) {
   return wordToWasmResult(Exports::get_buffer_bytes(current_context_, WS(type), WS(start),
                                                     WS(length), WR(ptr), WR(size)));
 }
 
-inline WasmResult proxy_get_buffer_status(BufferType type, size_t* length_ptr,
+inline WasmResult proxy_get_buffer_status(WasmBufferType type, size_t* length_ptr,
                                           uint32_t* flags_ptr) {
   return wordToWasmResult(
       Exports::get_buffer_status(current_context_, WS(type), WR(length_ptr), WR(flags_ptr)));
 }
 
-inline WasmResult proxy_set_buffer_bytes(BufferType type, uint64_t start, uint64_t length,
+inline WasmResult proxy_set_buffer_bytes(WasmBufferType type, uint64_t start, uint64_t length,
                                          const char* data_ptr, size_t data_size) {
   return wordToWasmResult(Exports::set_buffer_bytes(current_context_, WS(type), WS(start),
                                                     WS(length), WR(data_ptr), WS(data_size)));
 }
 
 // Headers/Trailers/Metadata Maps
-inline WasmResult proxy_add_header_map_value(HeaderMapType type, const char* key_ptr,
+inline WasmResult proxy_add_header_map_value(WasmHeaderMapType type, const char* key_ptr,
                                              size_t key_size, const char* value_ptr,
                                              size_t value_size) {
   return wordToWasmResult(Exports::add_header_map_value(
       current_context_, WS(type), WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size)));
 }
-inline WasmResult proxy_get_header_map_value(HeaderMapType type, const char* key_ptr,
+inline WasmResult proxy_get_header_map_value(WasmHeaderMapType type, const char* key_ptr,
                                              size_t key_size, const char** value_ptr,
                                              size_t* value_size) {
   return wordToWasmResult(Exports::get_header_map_value(
       current_context_, WS(type), WR(key_ptr), WS(key_size), WR(value_ptr), WR(value_size)));
 }
-inline WasmResult proxy_get_header_map_pairs(HeaderMapType type, const char** ptr, size_t* size) {
+inline WasmResult proxy_get_header_map_pairs(WasmHeaderMapType type, const char** ptr,
+                                             size_t* size) {
   return wordToWasmResult(
       Exports::get_header_map_pairs(current_context_, WS(type), WR(ptr), WR(size)));
 }
-inline WasmResult proxy_set_header_map_pairs(HeaderMapType type, const char* ptr, size_t size) {
+inline WasmResult proxy_set_header_map_pairs(WasmHeaderMapType type, const char* ptr, size_t size) {
   return wordToWasmResult(
       Exports::set_header_map_pairs(current_context_, WS(type), WR(ptr), WS(size)));
 }
-inline WasmResult proxy_replace_header_map_value(HeaderMapType type, const char* key_ptr,
+inline WasmResult proxy_replace_header_map_value(WasmHeaderMapType type, const char* key_ptr,
                                                  size_t key_size, const char* value_ptr,
                                                  size_t value_size) {
   return wordToWasmResult(Exports::replace_header_map_value(
       current_context_, WS(type), WR(key_ptr), WS(key_size), WR(value_ptr), WS(value_size)));
 }
-inline WasmResult proxy_remove_header_map_value(HeaderMapType type, const char* key_ptr,
+inline WasmResult proxy_remove_header_map_value(WasmHeaderMapType type, const char* key_ptr,
                                                 size_t key_size) {
   return wordToWasmResult(
       Exports::remove_header_map_value(current_context_, WS(type), WR(key_ptr), WS(key_size)));
 }
-inline WasmResult proxy_get_header_map_size(HeaderMapType type, size_t* size) {
+inline WasmResult proxy_get_header_map_size(WasmHeaderMapType type, size_t* size) {
   return wordToWasmResult(Exports::get_header_map_size(current_context_, WS(type), WR(size)));
 }
 

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -34,8 +34,6 @@ namespace Extensions {
 namespace Common {
 namespace Wasm {
 
-#include "api/wasm/cpp/proxy_wasm_common.h"
-
 #define ALL_WASM_STATS(COUNTER, GAUGE)                                                             \
   COUNTER(created)                                                                                 \
   GAUGE(active, NeverImport)


### PR DESCRIPTION
Followup PRs will move the .wasm code generation over
and will  move to use proxy-wasm-cpp-host.

Signed-off-by: John Plevyak <jplevyak@gmail.com>
