### PR TITLE
Fixes #472. Avoid segfault when wasm invokes httpCall to cluster whos…

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -914,6 +914,8 @@ WasmResult Context::httpCall(absl::string_view cluster, const Pairs& request_hea
     token = next_http_call_token_++;
   }
   auto& handler = http_request_[token];
+  handler.context_ = this;
+  handler.token_ = token;
 
   // set default hash policy to be based on :authority to enable consistent hash
   Http::AsyncClient::RequestOptions options;
@@ -928,8 +930,6 @@ WasmResult Context::httpCall(absl::string_view cluster, const Pairs& request_hea
     http_request_.erase(token);
     return WasmResult::InternalFailure;
   }
-  handler.context_ = this;
-  handler.token_ = token;
   handler.request_ = http_request;
   *token_ptr = token;
   return WasmResult::Ok;


### PR DESCRIPTION
…e DNS name cannot be resolved.

Signed-off-by: Robert Panzer <robert.panzer.pb@googlemail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: Bugfix for #472. Change order of initializing properties of AsyncClientHandler so that these are initialized in case the request is answered synchronously (by Envoy)

Risk Level: low

Testing: Currently only manual for the specific bug, the code base itself is tested. Unfortunately I am not capable right now to setup such a test. (I would happily learn to do that though if somebody tells me how. Looking at wasm_filter_test.cc I couldn't figure out how to mock the cluster manager to generate the required config

Docs Changes: None

Release Notes:
Fixes #472. Avoid segfault when invoking httpCall for a cluster whose DNS name cannot be resolved.

