### PR TITLE
wasm abi: tls certificate information retrieval

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1093,14 +1093,24 @@ const absl::optional<CertificateInfo> Context::getSslPeerCertificate() const {
     return absl::nullopt;
   }
   CertificateInfo certificate;
-  certificate.push_back(std::make_pair<absl::string_view>("serial_number", getConnection()->ssl()->serialNumberPeerCertificate()));
-  certificate.push_back(std::make_pair<absl::string_view>("issuer", getConnection()->ssl()->issuerPeerCertificate()));
-  certificate.push_back(std::make_pair<absl::string_view>("subject", getConnection()->ssl()->subjectPeerCertificate()));
-  certificate.push_back(std::make_pair<absl::string_view>("sha256_digest", getConnection()->ssl()->sha256PeerCertificateDigest()));
-  certificate.push_back(std::make_pair<absl::string_view>("validated", std::to_string(getConnection()->ssl()->peerCertificateValidated())));
-  certificate.push_back(std::make_pair<absl::string_view>("presented", std::to_string(getConnection()->ssl()->peerCertificatePresented())));
-  certificate.push_back(std::make_pair<absl::string_view>("uri_sans", absl::StrJoin(getConnection()->ssl()->uriSanPeerCertificate().begin(), getConnection()->ssl()->uriSanPeerCertificate().end(), ",")));
-  certificate.push_back(std::make_pair<absl::string_view>("dns_sans", absl::StrJoin(getConnection()->ssl()->dnsSansPeerCertificate().begin(), getConnection()->ssl()->dnsSansPeerCertificate().end(), ",")));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "serial_number", getConnection()->ssl()->serialNumberPeerCertificate()));
+  certificate.push_back(
+      std::make_pair<absl::string_view>("issuer", getConnection()->ssl()->issuerPeerCertificate()));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "subject", getConnection()->ssl()->subjectPeerCertificate()));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "sha256_digest", getConnection()->ssl()->sha256PeerCertificateDigest()));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "validated", std::to_string(getConnection()->ssl()->peerCertificateValidated())));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "presented", std::to_string(getConnection()->ssl()->peerCertificatePresented())));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "uri_sans", absl::StrJoin(getConnection()->ssl()->uriSanPeerCertificate().begin(),
+                                getConnection()->ssl()->uriSanPeerCertificate().end(), ",")));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "dns_sans", absl::StrJoin(getConnection()->ssl()->dnsSansPeerCertificate().begin(),
+                                getConnection()->ssl()->dnsSansPeerCertificate().end(), ",")));
   return certificate;
 }
 
@@ -1109,9 +1119,14 @@ const absl::optional<CertificateInfo> Context::getSslLocalCertificate() const {
     return absl::nullopt;
   }
   CertificateInfo certificate;
-  certificate.push_back(std::make_pair<absl::string_view>("subject", getConnection()->ssl()->subjectLocalCertificate()));
-  certificate.push_back(std::make_pair<absl::string_view>("uri_sans", absl::StrJoin(getConnection()->ssl()->uriSanPeerCertificate().begin(), getConnection()->ssl()->uriSanLocalCertificate().end(), ",")));
-  certificate.push_back(std::make_pair<absl::string_view>("dns_sans", absl::StrJoin(getConnection()->ssl()->dnsSansPeerCertificate().begin(), getConnection()->ssl()->dnsSansLocalCertificate().end(), ",")));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "subject", getConnection()->ssl()->subjectLocalCertificate()));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "uri_sans", absl::StrJoin(getConnection()->ssl()->uriSanPeerCertificate().begin(),
+                                getConnection()->ssl()->uriSanLocalCertificate().end(), ",")));
+  certificate.push_back(std::make_pair<absl::string_view>(
+      "dns_sans", absl::StrJoin(getConnection()->ssl()->dnsSansPeerCertificate().begin(),
+                                getConnection()->ssl()->dnsSansLocalCertificate().end(), ",")));
   return certificate;
 }
 

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -105,8 +105,8 @@ public:
   const Network::Connection* getConnection() const;
 
   // Retrieves ssl certificates info associated with connection.
-  const absl::optional<CertificateInfo> Context::getSslPeerCertificate() const;
-  const absl::optional<CertificateInfo> Context::getSslLocalCertificate() const;
+  const absl::optional<CertificateInfo> getSslPeerCertificate() const;
+  const absl::optional<CertificateInfo> getSslLocalCertificate() const;
 
   //
   // VM level downcalls into the WASM code on Context(id == 0).

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -28,6 +28,7 @@ class Wasm;
 class WasmVm;
 
 using Pairs = std::vector<std::pair<absl::string_view, absl::string_view>>;
+using CertificateInfo = std::vector<std::pair<absl::string_view, absl::string_view>>;
 using PairsWithStringValues = std::vector<std::pair<absl::string_view, std::string>>;
 
 using GrpcService = envoy::config::core::v3::GrpcService;
@@ -102,6 +103,10 @@ public:
   // callback. As long as any one of the callbacks is invoked, the value should be
   // available.
   const Network::Connection* getConnection() const;
+
+  // Retrieves ssl certificates info associated with connection.
+  const absl::optional<CertificateInfo> Context::getSslPeerCertificate() const;
+  const absl::optional<CertificateInfo> Context::getSslLocalCertificate() const;
 
   //
   // VM level downcalls into the WASM code on Context(id == 0).

--- a/source/extensions/common/wasm/exports.cc
+++ b/source/extensions/common/wasm/exports.cc
@@ -541,6 +541,30 @@ Word set_buffer_bytes(void* raw_context, Word type, Word start, Word length, Wor
   return wasmResultToWord(result);
 }
 
+Word get_peer_certificate_info(void* raw_context, Word value_ptr_ptr, Word value_size_ptr) {
+  auto context = WASM_CONTEXT(raw_context);
+  auto result = context->getSslPeerCertificate();
+  if (!result.has_value()) {
+    return wasmResultToWord(WasmResult::NotFound);
+  }
+  if (!getPairs(context, result.value(), value_ptr_ptr.u64_, value_size_ptr.u64_)) {
+    return wasmResultToWord(WasmResult::InvalidMemoryAccess);
+  }
+  return wasmResultToWord(WasmResult::Ok);
+}
+
+Word get_local_certificate_info(void* raw_context, Word value_ptr_ptr, Word value_size_ptr) {
+  auto context = WASM_CONTEXT(raw_context);
+  auto result = context->getSslLocalCertificate();
+  if (!result.has_value()) {
+    return wasmResultToWord(WasmResult::NotFound);
+  }
+  if (!getPairs(context, result.value(), value_ptr_ptr.u64_, value_size_ptr.u64_)) {
+    return wasmResultToWord(WasmResult::InvalidMemoryAccess);
+  }
+  return wasmResultToWord(WasmResult::Ok);
+}
+
 Word http_call(void* raw_context, Word uri_ptr, Word uri_size, Word header_pairs_ptr,
                Word header_pairs_size, Word body_ptr, Word body_size, Word trailer_pairs_ptr,
                Word trailer_pairs_size, Word timeout_milliseconds, Word token_ptr) {

--- a/source/extensions/common/wasm/exports.h
+++ b/source/extensions/common/wasm/exports.h
@@ -80,9 +80,10 @@ Word set_effective_context(void* raw_context, Word context_id);
 Word done(void* raw_context);
 Word call_foreign_function(void* raw_context, Word function_name, Word function_name_size,
                            Word arguments, Word warguments_size, Word results, Word results_size);
+Word get_peer_certificate_info(void* raw_context, Word value_ptr_ptr, Word value_size_ptr);
+Word get_local_certificate_info(void* raw_context, Word value_ptr_ptr, Word value_size_ptr);
 
 // Runtime environment functions exported from envoy to wasm.
-
 Word wasi_unstable_fd_write(void* raw_context, Word fd, Word iovs, Word iovs_len,
                             Word nwritten_ptr);
 Word wasi_unstable_fd_read(void*, Word, Word, Word, Word);

--- a/source/extensions/common/wasm/null/wasm_api_impl.h
+++ b/source/extensions/common/wasm/null/wasm_api_impl.h
@@ -183,6 +183,14 @@ inline WasmResult proxy_get_header_map_size(WasmHeaderMapType type, size_t* size
   return wordToWasmResult(Exports::get_header_map_size(current_context_, WS(type), WR(size)));
 }
 
+// TLS
+inline WasmResult proxy_get_peer_certificate_info(const char** ptr, size_t* size) {
+  return wordToWasmResult(Exports::get_peer_certificate_info(current_context_, WR(ptr), WR(size)));
+}
+inline WasmResult proxy_get_local_certificate_info(const char** ptr, size_t* size) {
+  return wordToWasmResult(Exports::get_local_certificate_info(current_context_, WR(ptr), WR(size)));
+}
+
 // HTTP
 // Returns token, used in callback onHttpCallResponse
 inline WasmResult proxy_http_call(const char* uri_ptr, size_t uri_size, void* header_pairs_ptr,

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -189,6 +189,9 @@ void Wasm::registerCallbacks() {
   _REGISTER_PROXY(get_buffer_bytes);
   _REGISTER_PROXY(set_buffer_bytes);
 
+  _REGISTER_PROXY(get_peer_certificate_info)
+  _REGISTER_PROXY(get_local_certificate_info)
+
   _REGISTER_PROXY(http_call);
 
   _REGISTER_PROXY(grpc_call);


### PR DESCRIPTION
Signed-off-by: shikugawa <Shikugawa@gmail.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: This is only a proposal implementation. I added instructions to retrieve local/peer certificate information. It is required to retrieve on AuthN filter wasm implementation. If there is no implementation to retrieve cert info via wasm VM, we should link upstream envoy connection info. It may cause the complexity of dependencies of AuthN wasm implementation.

https://github.com/istio/istio/issues/15772

Risk Level: Low
Testing: N/A
Docs Changes: Required
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
