### PR TITLE
Use the lifecycle manager to prevent Envoy from exiting until Wasm done.

### DIFF
--- a/include/envoy/server/BUILD
+++ b/include/envoy/server/BUILD
@@ -297,7 +297,6 @@ envoy_cc_library(
     hdrs = ["wasm_config.h"],
     deps = [
         ":wasm_interface",
-        "//include/envoy/api:api_interface",
-        "//include/envoy/event:dispatcher_interface",
+        "//include/envoy/server:instance_interface",
     ],
 )

--- a/include/envoy/server/wasm_config.h
+++ b/include/envoy/server/wasm_config.h
@@ -2,11 +2,8 @@
 
 #include "envoy/api/api.h"
 #include "envoy/common/pure.h"
-#include "envoy/event/dispatcher.h"
-#include "envoy/init/manager.h"
+#include "envoy/server/instance.h"
 #include "envoy/server/wasm.h"
-#include "envoy/thread_local/thread_local.h"
-#include "envoy/upstream/cluster_manager.h"
 
 #include "common/protobuf/protobuf.h"
 
@@ -16,46 +13,17 @@ namespace Configuration {
 
 class WasmFactoryContext {
 public:
-  virtual ~WasmFactoryContext() {}
+  virtual ~WasmFactoryContext() = default;
 
   /**
-   * @return Upstream::ClusterManager& singleton for use by the entire server.
+   * @return Server::Instance&.
    */
-  virtual Upstream::ClusterManager& clusterManager() PURE;
+  virtual Server::Instance& server() PURE;
 
-  /**
-   * @return Init:Manager& used by synchronizing the WASM initialization.
-   */
-  virtual Init::Manager& initManager() PURE;
-
-  /**
-   * @return Event::Dispatcher& the main thread's dispatcher. This dispatcher should be used
-   *         for all singleton processing.
-   */
-  virtual Event::Dispatcher& dispatcher() PURE;
-
-  /**
-   * @return ThreadLocal::SlotAllocator& the thread local storage engine for the server. This is
-   *         used to allow runtime lockless updates to configuration, etc. across multiple threads.
-   */
-  virtual ThreadLocal::SlotAllocator& threadLocal() PURE;
-  /**
-   * @return Api::Api& a reference to the api object.
-   */
-  virtual Api::Api& api() PURE;
   /**
    * @return Stats::ScopeSharedPtr the service's stats scope.
    */
   virtual Stats::ScopeSharedPtr& scope() PURE;
-  /**
-   * @return information about the local environment the server is running in.
-   */
-  virtual const LocalInfo::LocalInfo& localInfo() const PURE;
-
-  /**
-   * @return RandomGenerator& the random generator for the server.
-   */
-  virtual Envoy::Runtime::RandomGenerator& random() PURE;
 };
 
 /**
@@ -64,7 +32,7 @@ public:
  */
 class WasmFactory {
 public:
-  virtual ~WasmFactory() {}
+  virtual ~WasmFactory() = default;
 
   virtual std::string name() PURE;
 

--- a/source/extensions/access_loggers/wasm/config.cc
+++ b/source/extensions/access_loggers/wasm/config.cc
@@ -49,8 +49,8 @@ WasmAccessLogFactory::createAccessLogInstance(const Protobuf::Message& proto_con
 
   Common::Wasm::createWasm(config.config().vm_config(), plugin, context.scope().createScope(""),
                            context.clusterManager(), context.initManager(), context.dispatcher(),
-                           context.random(), context.api(), remote_data_provider_,
-                           std::move(callback));
+                           context.random(), context.api(), context.lifecycleNotifier(),
+                           remote_data_provider_, std::move(callback));
 
   return access_log;
 }

--- a/source/extensions/common/wasm/BUILD
+++ b/source/extensions/common/wasm/BUILD
@@ -69,6 +69,7 @@ envoy_cc_library(
         ":wasm_interoperation_lib",
         "//external:abseil_base",
         "//external:abseil_node_hash_map",
+        "//include/envoy/server:lifecycle_notifier_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:enum_to_int",
         "//source/common/http:message_lib",

--- a/source/extensions/filters/http/wasm/wasm_filter.cc
+++ b/source/extensions/filters/http/wasm/wasm_filter.cc
@@ -23,7 +23,7 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
       &context.listenerMetadata());
 
   auto plugin = plugin_;
-  auto callback = [plugin, this](Common::Wasm::WasmHandleSharedPtr base_wasm) {
+  auto callback = [plugin, this](const Common::Wasm::WasmHandleSharedPtr& base_wasm) {
     // NB: the Slot set() call doesn't complete inline, so all arguments must outlive this call.
     tls_slot_->set([base_wasm, plugin](Event::Dispatcher& dispatcher) {
       return std::static_pointer_cast<ThreadLocal::ThreadLocalObject>(
@@ -33,8 +33,8 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::http::wasm::v3::Was
 
   Common::Wasm::createWasm(config.config().vm_config(), plugin_, context.scope().createScope(""),
                            context.clusterManager(), context.initManager(), context.dispatcher(),
-                           context.random(), context.api(), remote_data_provider_,
-                           std::move(callback));
+                           context.random(), context.api(), context.lifecycleNotifier(),
+                           remote_data_provider_, std::move(callback));
 }
 
 } // namespace Wasm

--- a/source/extensions/filters/network/wasm/wasm_filter.cc
+++ b/source/extensions/filters/network/wasm/wasm_filter.cc
@@ -28,8 +28,8 @@ FilterConfig::FilterConfig(const envoy::extensions::filters::network::wasm::v3::
 
   Common::Wasm::createWasm(config.config().vm_config(), plugin_, context.scope().createScope(""),
                            context.clusterManager(), context.initManager(), context.dispatcher(),
-                           context.random(), context.api(), remote_data_provider_,
-                           std::move(callback));
+                           context.random(), context.api(), context.lifecycleNotifier(),
+                           remote_data_provider_, std::move(callback));
 }
 
 } // namespace Wasm

--- a/source/server/server.cc
+++ b/source/server/server.cc
@@ -434,9 +434,7 @@ void InstanceImpl::initialize(const Options& options,
     if (factory) {
       for (auto& config : bootstrap_.wasm_service()) {
         auto scope = Stats::ScopeSharedPtr(stats_store_.createScope(config.stat_prefix()));
-        Configuration::WasmFactoryContextImpl wasm_factory_context(
-            clusterManager(), initManager(), *dispatcher_, thread_local_, api(), scope, random(),
-            *local_info_);
+        Configuration::WasmFactoryContextImpl wasm_factory_context(*this, scope);
         factory->createWasm(config, wasm_factory_context, [this](WasmServicePtr wasm) {
           if (wasm) {
             // If not nullptr, this is a singleton WASM service.

--- a/source/server/wasm_config_impl.h
+++ b/source/server/wasm_config_impl.h
@@ -9,31 +9,15 @@ namespace Configuration {
 
 class WasmFactoryContextImpl : public WasmFactoryContext {
 public:
-  WasmFactoryContextImpl(Upstream::ClusterManager& cluster_manager, Init::Manager& init_manager,
-                         Event::Dispatcher& dispatcher, ThreadLocal::SlotAllocator& tls,
-                         Api::Api& api, Stats::ScopeSharedPtr scope,
-                         Runtime::RandomGenerator& random, const LocalInfo::LocalInfo& local_info)
-      : cluster_manager_(cluster_manager), init_manager_(init_manager), dispatcher_(dispatcher),
-        tls_(tls), api_(api), scope_(scope), random_(random), local_info_(local_info) {}
+  WasmFactoryContextImpl(Server::Instance& server, Stats::ScopeSharedPtr scope)
+      : server_(server), scope_(scope) {}
 
-  Upstream::ClusterManager& clusterManager() override { return cluster_manager_; }
-  Init::Manager& initManager() override { return init_manager_; }
-  Event::Dispatcher& dispatcher() override { return dispatcher_; }
-  ThreadLocal::SlotAllocator& threadLocal() override { return tls_; }
-  Api::Api& api() override { return api_; }
+  Server::Instance& server() override { return server_; }
   Stats::ScopeSharedPtr& scope() override { return scope_; }
-  const LocalInfo::LocalInfo& localInfo() const override { return local_info_; }
-  Envoy::Runtime::RandomGenerator& random() override { return random_; }
 
 private:
-  Upstream::ClusterManager& cluster_manager_;
-  Init::Manager& init_manager_;
-  Event::Dispatcher& dispatcher_;
-  ThreadLocal::SlotAllocator& tls_;
-  Api::Api& api_;
+  Server::Instance& server_;
   Stats::ScopeSharedPtr scope_;
-  Runtime::RandomGenerator& random_;
-  const LocalInfo::LocalInfo& local_info_;
 };
 
 } // namespace Configuration

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -1,8 +1,9 @@
+#include "envoy/server/lifecycle_notifier.h"
+
 #include "common/common/hex.h"
 #include "common/event/dispatcher_impl.h"
 #include "common/stats/isolated_store_impl.h"
 
-#include "envoy/server/lifecycle_notifier.h"
 #include "extensions/common/wasm/wasm.h"
 
 #include "test/mocks/server/mocks.h"

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -2,6 +2,7 @@
 #include "common/event/dispatcher_impl.h"
 #include "common/stats/isolated_store_impl.h"
 
+#include "envoy/server/lifecycle_notifier.h"
 #include "extensions/common/wasm/wasm.h"
 
 #include "test/mocks/server/mocks.h"
@@ -428,8 +429,9 @@ TEST_P(WasmCommonTest, VmCache) {
   Stats::IsolatedStoreImpl stats_store;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
-  NiceMock<Runtime::MockRandomGenerator> random_;
+  NiceMock<Runtime::MockRandomGenerator> random;
   NiceMock<Init::MockManager> init_manager;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher());
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
   auto scope = Stats::ScopeSharedPtr(stats_store.createScope("wasm."));
@@ -461,16 +463,18 @@ TEST_P(WasmCommonTest, VmCache) {
   EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_vm_start vm_cache")));
   EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_done logging")));
   EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_delete logging")));
-  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher,
-                       random_, *api, std::unique_ptr<Context>(root_context), remote_data_provider,
+  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher, random,
+                       *api, lifecycle_notifier, remote_data_provider,
+                       std::unique_ptr<Context>(root_context),
                        [&wasm_handle](const WasmHandleSharedPtr& w) { wasm_handle = w; });
 
   EXPECT_NE(wasm_handle, nullptr);
 
   WasmHandleSharedPtr wasm_handle2;
   auto root_context2 = new Extensions::Common::Wasm::Context();
-  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher,
-                       random_, *api, std::unique_ptr<Context>(root_context2), remote_data_provider,
+  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher, random,
+                       *api, lifecycle_notifier, remote_data_provider,
+                       std::unique_ptr<Context>(root_context2),
                        [&wasm_handle2](const WasmHandleSharedPtr& w) { wasm_handle2 = w; });
   EXPECT_NE(wasm_handle2, nullptr);
   EXPECT_EQ(wasm_handle, wasm_handle2);
@@ -493,8 +497,9 @@ TEST_P(WasmCommonTest, RemoteCode) {
   Stats::IsolatedStoreImpl stats_store;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
-  NiceMock<Runtime::MockRandomGenerator> random_;
+  NiceMock<Runtime::MockRandomGenerator> random;
   NiceMock<Init::MockManager> init_manager;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
   Init::ExpectableWatcherImpl init_watcher;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher());
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
@@ -548,8 +553,9 @@ TEST_P(WasmCommonTest, RemoteCode) {
   EXPECT_CALL(init_manager, add(_)).WillOnce(Invoke([&](const Init::Target& target) {
     init_target_handle = target.createHandle("test");
   }));
-  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher,
-                       random_, *api, std::unique_ptr<Context>(root_context), remote_data_provider,
+  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher, random,
+                       *api, lifecycle_notifier, remote_data_provider,
+                       std::unique_ptr<Context>(root_context),
                        [&wasm_handle](const WasmHandleSharedPtr& w) { wasm_handle = w; });
 
   EXPECT_CALL(init_watcher, ready());
@@ -573,8 +579,9 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
   Stats::IsolatedStoreImpl stats_store;
   Api::ApiPtr api = Api::createApiForTest(stats_store);
   NiceMock<Upstream::MockClusterManager> cluster_manager;
-  NiceMock<Runtime::MockRandomGenerator> random_;
+  NiceMock<Runtime::MockRandomGenerator> random;
   NiceMock<Init::MockManager> init_manager;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier;
   Init::ExpectableWatcherImpl init_watcher;
   Event::DispatcherPtr dispatcher(api->allocateDispatcher());
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider;
@@ -641,8 +648,9 @@ TEST_P(WasmCommonTest, RemoteCodeMultipleRetry) {
   EXPECT_CALL(init_manager, add(_)).WillOnce(Invoke([&](const Init::Target& target) {
     init_target_handle = target.createHandle("test");
   }));
-  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher,
-                       random_, *api, std::unique_ptr<Context>(root_context), remote_data_provider,
+  createWasmForTesting(vm_config, plugin, scope, cluster_manager, init_manager, *dispatcher, random,
+                       *api, lifecycle_notifier, remote_data_provider,
+                       std::unique_ptr<Context>(root_context),
                        [&wasm_handle](const WasmHandleSharedPtr& w) { wasm_handle = w; });
 
   EXPECT_CALL(init_watcher, ready());

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -5,6 +5,7 @@
 #include "common/stats/isolated_store_impl.h"
 #include "common/stream_info/stream_info_impl.h"
 
+#include "envoy/server/lifecycle_notifier.h"
 #include "extensions/common/wasm/wasm.h"
 #include "extensions/common/wasm/wasm_state.h"
 #include "extensions/filters/http/wasm/wasm_filter.h"
@@ -115,9 +116,9 @@ public:
         &listener_metadata_);
     Extensions::Common::Wasm::createWasmForTesting(
         proto_config.config().vm_config(), plugin_, scope_, cluster_manager_, init_manager_,
-        dispatcher_, random_, *api,
+        dispatcher_, random_, *api, lifecycle_notifier_, remote_data_provider_,
         std::unique_ptr<Envoy::Extensions::Common::Wasm::Context>(root_context_),
-        remote_data_provider_, [this](WasmHandleSharedPtr wasm) { wasm_ = wasm; });
+        [this](WasmHandleSharedPtr wasm) { wasm_ = wasm; });
   }
 
   void setupNullConfig(const std::string& name) {
@@ -140,9 +141,9 @@ public:
         &listener_metadata_);
     Extensions::Common::Wasm::createWasmForTesting(
         proto_config.config().vm_config(), plugin_, scope_, cluster_manager_, init_manager_,
-        dispatcher_, random_, *api,
+        dispatcher_, random_, *api, lifecycle_notifier_, remote_data_provider_,
         std::unique_ptr<Envoy::Extensions::Common::Wasm::Context>(root_context_),
-        remote_data_provider_, [this](WasmHandleSharedPtr wasm) { wasm_ = wasm; });
+        [this](WasmHandleSharedPtr wasm) { wasm_ = wasm; });
   }
 
   void setupFilter(const std::string root_id = "") {
@@ -168,6 +169,7 @@ public:
   NiceMock<Http::MockStreamEncoderFilterCallbacks> encoder_callbacks_;
   NiceMock<Envoy::StreamInfo::MockStreamInfo> request_stream_info_;
   NiceMock<LocalInfo::MockLocalInfo> local_info_;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier_;
   envoy::config::core::v3::Metadata listener_metadata_;
   TestRoot* root_context_ = nullptr;
   Config::DataSource::RemoteAsyncDataProviderPtr remote_data_provider_;

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -1,11 +1,12 @@
 #include <stdio.h>
 
+#include "envoy/server/lifecycle_notifier.h"
+
 #include "common/buffer/buffer_impl.h"
 #include "common/http/message_impl.h"
 #include "common/stats/isolated_store_impl.h"
 #include "common/stream_info/stream_info_impl.h"
 
-#include "envoy/server/lifecycle_notifier.h"
 #include "extensions/common/wasm/wasm.h"
 #include "extensions/common/wasm/wasm_state.h"
 #include "extensions/filters/http/wasm/wasm_filter.h"

--- a/test/extensions/filters/network/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/network/wasm/wasm_filter_test.cc
@@ -1,4 +1,5 @@
 #include "envoy/server/lifecycle_notifier.h"
+
 #include "extensions/common/wasm/wasm.h"
 #include "extensions/filters/network/wasm/wasm_filter.h"
 

--- a/test/extensions/filters/network/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/network/wasm/wasm_filter_test.cc
@@ -1,3 +1,4 @@
+#include "envoy/server/lifecycle_notifier.h"
 #include "extensions/common/wasm/wasm.h"
 #include "extensions/filters/network/wasm/wasm_filter.h"
 
@@ -66,9 +67,9 @@ public:
         envoy::config::core::v3::TrafficDirection::INBOUND, local_info_, &listener_metadata_);
     Extensions::Common::Wasm::createWasmForTesting(
         proto_config.config().vm_config(), plugin_, scope_, cluster_manager_, init_manager_,
-        dispatcher_, random_, *api,
+        dispatcher_, random_, *api, lifecycle_notifier_, remote_data_provider_,
         std::unique_ptr<Envoy::Extensions::Common::Wasm::Context>(root_context_),
-        remote_data_provider_, [this](Common::Wasm::WasmHandleSharedPtr wasm) { wasm_ = wasm; });
+        [this](Common::Wasm::WasmHandleSharedPtr wasm) { wasm_ = wasm; });
   }
 
   void setupFilter() {
@@ -83,6 +84,7 @@ public:
   NiceMock<Upstream::MockClusterManager> cluster_manager_;
   NiceMock<Runtime::MockRandomGenerator> random_;
   NiceMock<Init::MockManager> init_manager_;
+  NiceMock<Server::MockServerLifecycleNotifier> lifecycle_notifier_;
   Common::Wasm::WasmHandleSharedPtr wasm_;
   Common::Wasm::PluginSharedPtr plugin_;
   std::unique_ptr<TestFilter> filter_;


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>

