### PR TITLE
Changed DefaultTimeout interval to 10s

### DIFF
--- a/test/test_common/utility.h
+++ b/test/test_common/utility.h
@@ -468,7 +468,7 @@ public:
   static std::string convertTime(const std::string& input, const std::string& input_format,
                                  const std::string& output_format);
 
-  static constexpr std::chrono::milliseconds DefaultTimeout = std::chrono::milliseconds(30000);
+  static constexpr std::chrono::milliseconds DefaultTimeout = std::chrono::milliseconds(10000);
 
   /**
    * Return a prefix string matcher.


### PR DESCRIPTION
It should be less than DEFAULT_ROUTE_TIMEOUT_MS of 15s to stop intermittent failures in  test/integration/protocol_integration_test.