### PR TITLE
Upgrade to cel-cpp v0.2.0 to pick up ANTLR thread-safety changes.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -297,7 +297,7 @@ REPOSITORY_LOCATIONS = dict(
     ),
     com_google_cel_cpp = dict(
         sha256 = "d773ee368053f404eada87b59c9e545b2e21118ebb0577ac3e942a06518f6fd2",
-        strip_prefix = "cel-cpp-v0.2.0",
+        strip_prefix = "cel-cpp-0.2.0",
         # 2020-05-11
         urls = ["https://github.com/google/cel-cpp/archive/v0.2.0.tar.gz"],
     ),

--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -296,10 +296,10 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://storage.googleapis.com/quiche-envoy-integration/googleurl_dbf5ad147f60afc125e99db7549402af49a5eae8.tar.gz"],
     ),
     com_google_cel_cpp = dict(
-        sha256 = "7eddffdb231e7c82f60c597cd38e742fbc0c48f54ca33015ac0a3d22bd51bba3",
-        strip_prefix = "cel-cpp-d88a4822af1864b481b31b12c2ecc4e631a7f8a9",
-        # 2019-04-13
-        urls = ["https://github.com/google/cel-cpp/archive/d88a4822af1864b481b31b12c2ecc4e631a7f8a9.tar.gz"],
+        sha256 = "d773ee368053f404eada87b59c9e545b2e21118ebb0577ac3e942a06518f6fd2",
+        strip_prefix = "cel-cpp-v0.2.0",
+        # 2020-05-11
+        urls = ["https://github.com/google/cel-cpp/archive/v0.2.0.tar.gz"],
     ),
     com_github_google_flatbuffers = dict(
         sha256 = "b8efbc25721e76780752bad775a97c3f77a0250271e2db37fc747b20e8b0f24a",

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -281,7 +281,7 @@ public:
     static const std::vector<google::api::expr::runtime::CelAttributePattern> empty;
     return empty;
   }
-  const Protobuf::FieldMask unknown_paths() const override {
+  const Protobuf::FieldMask& unknown_paths() const override {
     return Protobuf::FieldMask::default_instance();
   }
 


### PR DESCRIPTION
Signed-off-by: Tristan Swadell <tswadell@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description: The CEL module used by Envoy-WASM is not thread-safe. A recent upgrade within the https://github.com/google/cel-cpp repo upgraded the C++ ANTLR runtime from v4.7.1 to v4.7.2 with a repro case to verify the thread-unsafe before behavior and the thread-safe after behavior. There may be additional issues above CEL within the Envoy-WASM stack which caused the segfault in https://github.com/envoyproxy/envoy-wasm/issues/497; however, the change should remove a number of possible bugs and narrow the scope of the segfault search.

Risk Level: Low
Testing: Unit testing in the cel-cpp stack.
Docs Changes: n/a
Release Notes: CEL thread-safety improvements
[Optional Fixes #Issue]
[Optional Deprecated:]
