### PR TITLE
Add support for all headers statuses returned by WASM.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -346,14 +346,14 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/dpkp/kafka-python/archive/2.0.0.tar.gz"],
     ),
     proxy_wasm_cpp_sdk = dict(
-        sha256 = "31e72756adfdefd6a5d1254a1131347c694a84bb1157d729c805663e97296e2c",
-        strip_prefix = "proxy-wasm-cpp-sdk-e81783ca9a41219995ef4ad7ca21a328485eb789",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/e81783ca9a41219995ef4ad7ca21a328485eb789.tar.gz"],
+        sha256 = "3531281b8190ff532b730e92c1f247a2b87995f17a4fd9eaf2ebac6136fbc308",
+        strip_prefix = "proxy-wasm-cpp-sdk-96927d814b3ec14893b56793e122125e095654c7",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/96927d814b3ec14893b56793e122125e095654c7.tar.gz"],
     ),
     proxy_wasm_cpp_host = dict(
-        sha256 = "36055f81db73f18266683128ae5063e912629af1b262898838ab4290586b3b15",
-        strip_prefix = "proxy-wasm-cpp-host-77f46caf12064d7b03740382b61a1be6a37cbd19",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/77f46caf12064d7b03740382b61a1be6a37cbd19.tar.gz"],
+        sha256 = "20507efa4d22d093baf95438375ec2b677e1d4ce4cd87b7318de4d0f12e664ce",
+        strip_prefix = "proxy-wasm-cpp-host-6b9a5d8ee85a1bf72d276fef2252b44346464e7b",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/6b9a5d8ee85a1bf72d276fef2252b44346464e7b.tar.gz"],
     ),
     emscripten_toolchain = dict(
         sha256 = "4ac0f1f3de8b3f1373d435cd7e58bd94de4146e751f099732167749a229b443b",

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1146,6 +1146,12 @@ Http::FilterHeadersStatus convertFilterHeadersStatus(proxy_wasm::FilterHeadersSt
     return Http::FilterHeadersStatus::Continue;
   case proxy_wasm::FilterHeadersStatus::StopIteration:
     return Http::FilterHeadersStatus::StopIteration;
+  case proxy_wasm::FilterHeadersStatus::ContinueAndEndStream:
+    return Http::FilterHeadersStatus::ContinueAndEndStream;
+  case proxy_wasm::FilterHeadersStatus::StopAllIterationAndBuffer:
+    return Http::FilterHeadersStatus::StopAllIterationAndBuffer;
+  case proxy_wasm::FilterHeadersStatus::StopAllIterationAndWatermark:
+    return Http::FilterHeadersStatus::StopAllIterationAndWatermark;
   }
   NOT_IMPLEMENTED_GCOVR_EXCL_LINE;
 };

--- a/test/extensions/filters/http/wasm/test_data/headers_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/headers_cpp.cc
@@ -37,6 +37,12 @@ FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
   replaceRequestHeader("server", "envoy-wasm");
   if (server->view() == "envoy-wasm-pause") {
     return FilterHeadersStatus::StopIteration;
+  } else if (server->view() == "envoy-wasm-end-stream") {
+    return FilterHeadersStatus::ContinueAndEndStream;
+  } else if (server->view() == "envoy-wasm-stop-buffer") {
+    return FilterHeadersStatus::StopAllIterationAndBuffer;
+  } else if (server->view() == "envoy-wasm-stop-watermark") {
+    return FilterHeadersStatus::StopAllIterationAndWatermark;
   } else {
     return FilterHeadersStatus::Continue;
   }


### PR DESCRIPTION
This requires the changes made to proxy-wasm-cpp-sdk
in https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/pull/19.

With this change, a WASM filter can return, say,
StopAllIterationAndWatermark. This is useful when a WASM filter
might want to call an external service and use the result to
change an HTTP header before continuing processing the body.

This PR will NOT build unless the following other PRs are merged:

https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/19
https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/pull/19

Signed-off-by: Gregory Brail <gregbrail@google.com>