### PR TITLE
Implement setTimerPeriod method

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -158,7 +158,7 @@ void Context::initializeRoot(WasmBase* wasm, std::shared_ptr<PluginBase> plugin)
 }
 
 WasmResult Context::setTimerPeriod(std::chrono::milliseconds tick_period, uint32_t*) {
-  wasm()->setTickPeriod(root_context_id_ ? root_context_id_ : id_, tick_period);
+  wasm()->setTimerPeriod(root_context_id_ ? root_context_id_ : id_, tick_period);
   return WasmResult::Ok;
 }
 

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -157,7 +157,7 @@ void Context::initializeRoot(WasmBase* wasm, std::shared_ptr<PluginBase> plugin)
   root_local_info_ = &std::static_pointer_cast<Plugin>(plugin)->local_info_;
 }
 
-WasmResult Context::setTickPeriod(std::chrono::milliseconds tick_period) {
+WasmResult Context::setTimerPeriod(std::chrono::milliseconds tick_period, uint32_t*) {
   wasm()->setTickPeriod(root_context_id_ ? root_context_id_ : id_, tick_period);
   return WasmResult::Ok;
 }

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -192,8 +192,8 @@ public:
 
   // General
   WasmResult log(uint32_t level, absl::string_view message) override;
-  uint64_t getCurrentTimeNanoseconds() override;
   WasmResult setTimerPeriod(std::chrono::milliseconds tick_period, uint32_t* token) override;
+  uint64_t getCurrentTimeNanoseconds() override;
   std::pair<uint32_t, absl::string_view> getStatus() override;
 
   // State accessors

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -193,6 +193,7 @@ public:
   // General
   WasmResult log(uint32_t level, absl::string_view message) override;
   uint64_t getCurrentTimeNanoseconds() override;
+  WasmResult setTimerPeriod(std::chrono::milliseconds tick_period, uint32_t* token) override;
   std::pair<uint32_t, absl::string_view> getStatus() override;
 
   // State accessors
@@ -295,7 +296,6 @@ protected:
   void onCloseTCP();
 
   virtual absl::string_view getConfiguration();
-  virtual WasmResult setTickPeriod(std::chrono::milliseconds tick_period);
   virtual void clearRouteCache() {
     if (decoder_callbacks_) {
       decoder_callbacks_->clearRouteCache();

--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -117,7 +117,7 @@ Wasm::Wasm(WasmHandleSharedPtr base_wasm_handle, Event::Dispatcher& dispatcher)
   ENVOY_LOG(debug, "Thread-Local Wasm created {} now active", active_wasms);
 }
 
-void Wasm::setTickPeriod(uint32_t context_id, std::chrono::milliseconds new_tick_period) {
+void Wasm::setTimerPeriod(uint32_t context_id, std::chrono::milliseconds new_tick_period) {
   auto& tick_period = tick_period_[context_id];
   auto& timer = timer_[context_id];
   bool was_running = timer && tick_period.count() > 0;

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -58,7 +58,7 @@ public:
   Context* getRootContext(absl::string_view root_id) {
     return static_cast<Context*>(WasmBase::getRootContext(root_id));
   }
-  void setTimerPeriod(uint32_t root_context_id, std::chrono::milliseconds tick_period) override;
+  void setTimerPeriod(uint32_t root_context_id, std::chrono::milliseconds tick_period);
   virtual void tickHandler(uint32_t root_context_id);
 
   // WasmBase

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -58,7 +58,7 @@ public:
   Context* getRootContext(absl::string_view root_id) {
     return static_cast<Context*>(WasmBase::getRootContext(root_id));
   }
-  void setTickPeriod(uint32_t root_context_id, std::chrono::milliseconds tick_period) override;
+  void setTimerPeriod(uint32_t root_context_id, std::chrono::milliseconds tick_period) override;
   virtual void tickHandler(uint32_t root_context_id);
 
   // WasmBase

--- a/test/extensions/wasm/wasm_test.cc
+++ b/test/extensions/wasm/wasm_test.cc
@@ -30,7 +30,6 @@ public:
     return proxy_wasm::WasmResult::Ok;
   }
   MOCK_METHOD2(log_, void(spdlog::level::level_enum level, absl::string_view message));
-  MOCK_METHOD1(setTickPeriodMilliseconds, void(uint32_t tick_period_milliseconds));
 };
 
 class WasmTestBase {


### PR DESCRIPTION
This does not implement the timer token, just override the virtual method to avoid unimplemented error.

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Fixes #Issue]
[Optional Deprecated:]
