### PR TITLE
Pass the "end_of_stream" flag to header callbacks.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -351,9 +351,9 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/96927d814b3ec14893b56793e122125e095654c7.tar.gz"],
     ),
     proxy_wasm_cpp_host = dict(
-        sha256 = "3f0490f0b4aa3d856c89eb0a63d004059b071a3d3b81c36813fe70940ba48d5a",
-        strip_prefix = "proxy-wasm-cpp-host-39a594388dcd28f748c80eb5f81ad5233a2de579",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/39a594388dcd28f748c80eb5f81ad5233a2de579.tar.gz"],
+        sha256 = "08f90872054779e966bcedafaed44faebaf5277696aea6d1ba4975f097c3cd8d",
+        strip_prefix = "proxy-wasm-cpp-host-65652f008f9f19be958d84b023ce2511c0dca3ae",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/65652f008f9f19be958d84b023ce2511c0dca3ae.tar.gz"],
     ),
     emscripten_toolchain = dict(
         sha256 = "4ac0f1f3de8b3f1373d435cd7e58bd94de4146e751f099732167749a229b443b",

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1310,7 +1310,7 @@ WasmResult Context::sendLocalResponse(uint32_t response_code, absl::string_view 
 Http::FilterHeadersStatus Context::decodeHeaders(Http::RequestHeaderMap& headers, bool end_stream) {
   request_headers_ = &headers;
   end_of_stream_ = end_stream;
-  auto result = convertFilterHeadersStatus(onRequestHeaders(headerSize(&headers)));
+  auto result = convertFilterHeadersStatus(onRequestHeaders(headerSize(&headers), end_stream));
   if (result == Http::FilterHeadersStatus::Continue) {
     request_headers_ = nullptr;
   }
@@ -1366,7 +1366,7 @@ Http::FilterHeadersStatus Context::encodeHeaders(Http::ResponseHeaderMap& header
                                                  bool end_stream) {
   response_headers_ = &headers;
   end_of_stream_ = end_stream;
-  auto result = convertFilterHeadersStatus(onResponseHeaders(headerSize(&headers)));
+  auto result = convertFilterHeadersStatus(onResponseHeaders(headerSize(&headers), end_stream));
   if (result == Http::FilterHeadersStatus::Continue) {
     response_headers_ = nullptr;
   }


### PR DESCRIPTION
Pass the end_of_stream flag to the onRequestHeaders and onResponseHeaders callbacks so that WASM proxies can later use them. (Right now they don't -- that will be addressed in another PR to proxy-wasm-cpp-host.)

This begins to address:

https://github.com/envoyproxy/envoy-wasm/issues/446

This won't build until
https://github.com/proxy-wasm/proxy-wasm-cpp-host/pull/21
is merged.

Signed-off-by: Gregory Brail <gregbrail@google.com>
