### PR TITLE
Fix unwanted fallthrough in continueStream.

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1275,6 +1275,7 @@ WasmResult Context::continueStream(StreamType stream_type) {
     if (decoder_callbacks_) {
       decoder_callbacks_->continueDecoding();
     }
+    break;
   case StreamType::Response:
     if (encoder_callbacks_) {
       encoder_callbacks_->continueEncoding();


### PR DESCRIPTION
This was causing a call to continue_request to fall through and call continue_response as well, which resulted in an assertion failure in Envoy.

Signed-off-by: Gregory Brail <gregbrail@google.com>


