### PR TITLE
Update to WASM versions that pass end_of_stream to headers.

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -346,14 +346,14 @@ REPOSITORY_LOCATIONS = dict(
         urls = ["https://github.com/dpkp/kafka-python/archive/2.0.0.tar.gz"],
     ),
     proxy_wasm_cpp_sdk = dict(
-        sha256 = "3531281b8190ff532b730e92c1f247a2b87995f17a4fd9eaf2ebac6136fbc308",
-        strip_prefix = "proxy-wasm-cpp-sdk-96927d814b3ec14893b56793e122125e095654c7",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/96927d814b3ec14893b56793e122125e095654c7.tar.gz"],
+        sha256 = "e92312ac743797e18b727d88262e8f8da0e4e7b0e825ed791d6c2d7de6cfdfb2",
+        strip_prefix = "proxy-wasm-cpp-sdk-b273b07ae0cfa9cc76dfe38236b163e9e3a2ab49",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/b273b07ae0cfa9cc76dfe38236b163e9e3a2ab49.tar.gz"],
     ),
     proxy_wasm_cpp_host = dict(
-        sha256 = "08f90872054779e966bcedafaed44faebaf5277696aea6d1ba4975f097c3cd8d",
-        strip_prefix = "proxy-wasm-cpp-host-65652f008f9f19be958d84b023ce2511c0dca3ae",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/65652f008f9f19be958d84b023ce2511c0dca3ae.tar.gz"],
+        sha256 = "55d15a7f320b5236e6f05a3ebb06b1af43131b20f1f040a681b04566b7e76bb6",
+        strip_prefix = "proxy-wasm-cpp-host-b55f5baa55c2af7965e3dc4f6788cdd6b5f5a27f",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/b55f5baa55c2af7965e3dc4f6788cdd6b5f5a27f.tar.gz"],
     ),
     emscripten_toolchain = dict(
         sha256 = "4ac0f1f3de8b3f1373d435cd7e58bd94de4146e751f099732167749a229b443b",

--- a/test/extensions/access_loggers/wasm/test_data/logging_cpp.cc
+++ b/test/extensions/access_loggers/wasm/test_data/logging_cpp.cc
@@ -8,14 +8,14 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t headers) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t headers, bool) override;
   FilterDataStatus onRequestBody(size_t body_buffer_length, bool end_of_stream) override;
   void onLog() override;
   void onDone() override;
 };
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext));
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   logDebug(std::string("onRequestHeaders ") + std::to_string(id()));
   auto path = getRequestHeader(":path");
   logInfo(std::string("header path ") + std::string(path->view()));

--- a/test/extensions/filters/http/wasm/test_data/async_call_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/async_call_cpp.cc
@@ -8,11 +8,11 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
 };
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext));
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   auto context_id = id();
   auto callback = [context_id](uint32_t, size_t body_size, uint32_t) {
     auto response_headers = getHeaderMapPairs(WasmHeaderMapType::HttpCallResponseHeaders);

--- a/test/extensions/filters/http/wasm/test_data/body_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/body_cpp.cc
@@ -10,8 +10,8 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
-  FilterHeadersStatus onResponseHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
+  FilterHeadersStatus onResponseHeaders(uint32_t, bool) override;
   FilterDataStatus onRequestBody(size_t body_buffer_length, bool end_of_stream) override;
   FilterDataStatus onResponseBody(size_t body_buffer_length, bool end_of_stream) override;
 
@@ -24,12 +24,12 @@ private:
 };
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext));
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   test_op_ = getRequestHeader("x-test-operation")->toString();
   return FilterHeadersStatus::Continue;
 }
 
-FilterHeadersStatus ExampleContext::onResponseHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onResponseHeaders(uint32_t, bool) {
   test_op_ = getResponseHeader("x-test-operation")->toString();
   return FilterHeadersStatus::Continue;
 }

--- a/test/extensions/filters/http/wasm/test_data/grpc_call_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/grpc_call_cpp.cc
@@ -10,7 +10,7 @@ public:
 
   FilterHeadersStatus onRequestHeadersSimple(uint32_t);
   FilterHeadersStatus onRequestHeadersStream(uint32_t);
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
 };
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext));
 
@@ -82,7 +82,7 @@ FilterHeadersStatus ExampleContext::onRequestHeadersStream(uint32_t) {
   return FilterHeadersStatus::StopIteration;
 }
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   GrpcService grpc_service;
   grpc_service.mutable_envoy_grpc()->set_cluster_name("cluster");
   std::string grpc_service_string;

--- a/test/extensions/filters/http/wasm/test_data/headers_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/headers_cpp.cc
@@ -8,7 +8,7 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
   FilterDataStatus onRequestBody(size_t body_buffer_length, bool end_of_stream) override;
   void onLog() override;
   void onDone() override;
@@ -26,7 +26,7 @@ public:
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext),
                                                       ROOT_FACTORY(ExampleRootContext));
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   static_cast<ExampleRootContext*>(root())->stream_context_id_ = id();
   logDebug(std::string("onRequestHeaders ") + std::to_string(id()));
   auto path = getRequestHeader(":path");

--- a/test/extensions/filters/http/wasm/test_data/metadata_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/metadata_cpp.cc
@@ -9,7 +9,7 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
   FilterDataStatus onRequestBody(size_t body_buffer_length, bool end_of_stream) override;
   void onLog() override;
   void onDone() override;
@@ -30,7 +30,7 @@ void ExampleRootContext::onTick() {
   logDebug(std::string("onTick ") + value);
 }
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   std::string value;
   if (!getValue({"node", "metadata", "wasm_node_get_key"}, &value)) {
     logDebug("missing node metadata");

--- a/test/extensions/filters/http/wasm/test_data/null_plugin/plugin.cc
+++ b/test/extensions/filters/http/wasm/test_data/null_plugin/plugin.cc
@@ -72,7 +72,7 @@ class PluginContext : public Context {
 public:
   explicit PluginContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t headers) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t headers, bool end_of_stream) override;
   FilterDataStatus onRequestBody(size_t body_buffer_length, bool end_of_stream) override;
   void onLog() override;
   void onDone() override;
@@ -80,7 +80,7 @@ public:
 static RegisterContextFactory register_PluginContext(CONTEXT_FACTORY(PluginContext),
                                                      ROOT_FACTORY(PluginRootContext));
 
-FilterHeadersStatus PluginContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus PluginContext::onRequestHeaders(uint32_t, bool) {
   logDebug(std::string("onRequestHeaders ") + std::to_string(id()));
   auto path = getRequestHeader(":path");
   logInfo(std::string("header path ") + std::string(path->view()));

--- a/test/extensions/filters/http/wasm/test_data/queue_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/queue_cpp.cc
@@ -8,7 +8,7 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
 };
 
 class ExampleRootContext : public RootContext {
@@ -24,7 +24,7 @@ public:
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext),
                                                       ROOT_FACTORY(ExampleRootContext));
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   uint32_t token;
   if (resolveSharedQueue("vm_id", "bad_shared_queue", &token) == WasmResult::NotFound) {
     logWarn("onRequestHeaders not found bad_shared_queue");

--- a/test/extensions/filters/http/wasm/test_data/root_id_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/root_id_cpp.cc
@@ -7,24 +7,24 @@
 class Context1 : public Context {
 public:
   Context1(uint32_t id, RootContext* root) : Context(id, root) {}
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
 };
 
 class Context2 : public Context {
 public:
   Context2(uint32_t id, RootContext* root) : Context(id, root) {}
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
 };
 
 static RegisterContextFactory register_Context1(CONTEXT_FACTORY(Context1), "context1");
 static RegisterContextFactory register_Contxt2(CONTEXT_FACTORY(Context2), "context2");
 
-FilterHeadersStatus Context1::onRequestHeaders(uint32_t) {
+FilterHeadersStatus Context1::onRequestHeaders(uint32_t, bool) {
   logDebug(std::string("onRequestHeaders1 ") + std::to_string(id()));
   return FilterHeadersStatus::Continue;
 }
 
-FilterHeadersStatus Context2::onRequestHeaders(uint32_t) {
+FilterHeadersStatus Context2::onRequestHeaders(uint32_t, bool) {
   logDebug(std::string("onRequestHeaders2 ") + std::to_string(id()));
   return FilterHeadersStatus::Continue;
 }

--- a/test/extensions/filters/http/wasm/test_data/shared_cpp.cc
+++ b/test/extensions/filters/http/wasm/test_data/shared_cpp.cc
@@ -8,12 +8,12 @@ class ExampleContext : public Context {
 public:
   explicit ExampleContext(uint32_t id, RootContext* root) : Context(id, root) {}
 
-  FilterHeadersStatus onRequestHeaders(uint32_t) override;
+  FilterHeadersStatus onRequestHeaders(uint32_t, bool) override;
   void onLog() override;
 };
 static RegisterContextFactory register_ExampleContext(CONTEXT_FACTORY(ExampleContext));
 
-FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t) {
+FilterHeadersStatus ExampleContext::onRequestHeaders(uint32_t, bool) {
   WasmDataPtr value0;
   if (getSharedData("shared_data_key_bad", &value0) == WasmResult::NotFound) {
     logDebug("get of bad key not found");


### PR DESCRIPTION
See https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/pull/25 for details on the SDK API changes required by this new flag.

Fix tests so that they use the new flag.

Signed-off-by: Gregory Brail <gregbrail@google.com>
