### PR TITLE
platform: avoid name confliction between platform header and emscripten-libc

### DIFF
--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -193,7 +193,7 @@ using os_fd_t = int;
 // Therefore, we decided to remove the Android check introduced here in
 // https://github.com/envoyproxy/envoy/pull/10120. If someone out there encounters problems with
 // this please bring up in Envoy's slack channel #envoy-udp-quic-dev.
-#if defined(__linux__)
+#if defined(__linux__) || defined(__EMSCRIPTEN__)
 #define ENVOY_MMSG_MORE 1
 #else
 #define ENVOY_MMSG_MORE 0
@@ -201,12 +201,9 @@ using os_fd_t = int;
 // Posix structure for describing messages sent by 'sendmmsg` and received by
 // 'recvmmsg'
 
-#ifndef __EMSCRIPTEN__
-
 struct mmsghdr {
   struct msghdr msg_hdr;
   unsigned int msg_len;
 };
 
-#endif
 #endif

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -200,8 +200,13 @@ using os_fd_t = int;
 #define MSG_WAITFORONE 0x10000 // recvmmsg(): block until 1+ packets avail.
 // Posix structure for describing messages sent by 'sendmmsg` and received by
 // 'recvmmsg'
+
+#ifndef __EMSCRIPTEN__
+
 struct mmsghdr {
   struct msghdr msg_hdr;
   unsigned int msg_len;
 };
+
+#endif
 #endif

--- a/include/envoy/common/platform.h
+++ b/include/envoy/common/platform.h
@@ -200,10 +200,8 @@ using os_fd_t = int;
 #define MSG_WAITFORONE 0x10000 // recvmmsg(): block until 1+ packets avail.
 // Posix structure for describing messages sent by 'sendmmsg` and received by
 // 'recvmmsg'
-
 struct mmsghdr {
   struct msghdr msg_hdr;
   unsigned int msg_len;
 };
-
 #endif


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Name confliction will occur when we build envoy common library by emscripten because of emscripten-libc. We can avoid this problem with this patch.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
