### PR TITLE
bazel: wasm to wasm32

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -502,9 +502,9 @@ DEPENDENCY_REPOSITORIES = dict(
         use_category = ["test"],
     ),
     proxy_wasm_cpp_sdk = dict(
-        sha256 = "76f4d8e8a41b59668272e58e68ded1661a0f9c1672bdab8673a076ebf20d1fe5",
-        strip_prefix = "proxy-wasm-cpp-sdk-35163bbf32fccfbde7b95d909a392dc1dc562596",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/35163bbf32fccfbde7b95d909a392dc1dc562596.tar.gz"],
+        sha256 = "2d06cda9edbb425d1fd3739cbcabb2be3b59db73f59e660758e8731393d77b68",
+        strip_prefix = "proxy-wasm-cpp-sdk-862c556304700620841d66b8bc5a3bfec96cb768",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/archive/862c556304700620841d66b8bc5a3bfec96cb768.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/bazel/wasm/wasm.bzl
+++ b/bazel/wasm/wasm.bzl
@@ -2,7 +2,7 @@ load("@rules_cc//cc:defs.bzl", "cc_binary")
 
 def _wasm_transition_impl(settings, attr):
     return {
-        "//command_line_option:cpu": "wasm",
+        "//command_line_option:cpu": "wasm32",
         "//command_line_option:crosstool_top": "@proxy_wasm_cpp_sdk//toolchain:emscripten",
 
         # Overriding copt/cxxopt/linkopt to prevent sanitizers/coverage options leak


### PR DESCRIPTION
Signed-off-by: Shikugawa <rei@tetrate.io>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Convert `wasm` to `wasm32` to follow with wasm spec.
Additional Description:
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
https://github.com/abseil/abseil-cpp/pull/721
https://github.com/google/re2/commit/b83705e2d297f21b0805202bac86c935670634f8
https://github.com/proxy-wasm/proxy-wasm-cpp-sdk/pull/30
[Optional Deprecated:]
