### PR TITLE
Prometheus scraper: Opt out of automatic namespacing

### DIFF
--- a/source/server/admin/prometheus_stats.cc
+++ b/source/server/admin/prometheus_stats.cc
@@ -188,6 +188,12 @@ std::string PrometheusStatsFormatter::formattedTags(const std::vector<Stats::Tag
 }
 
 std::string PrometheusStatsFormatter::metricName(const std::string& extracted_name) {
+  // Offer a way to opt out of automatic namespacing.
+  // If metric name starts with "_" it will be trimmed but not namespaced.
+  // It is the responsibility of the metric creator to ensure proper namespacing.
+  if (extracted_name.size() > 1 && extracted_name[0] == '_') {
+    return sanitizeName(extracted_name.substr(1));
+  }
   // Add namespacing prefix to avoid conflicts, as per best practice:
   // https://prometheus.io/docs/practices/naming/#metric-names
   // Also, naming conventions on https://prometheus.io/docs/concepts/data_model/

--- a/test/server/admin/prometheus_stats_test.cc
+++ b/test/server/admin/prometheus_stats_test.cc
@@ -107,6 +107,13 @@ TEST_F(PrometheusStatsFormatterTest, MetricName) {
   EXPECT_EQ(expected, actual);
 }
 
+TEST_F(PrometheusStatsFormatterTest, MetricNameOptOut) {
+  std::string raw = "_vulture.eats-liver";
+  std::string expected = "vulture_eats_liver";
+  auto actual = PrometheusStatsFormatter::metricName(raw);
+  EXPECT_EQ(expected, actual);
+}
+
 TEST_F(PrometheusStatsFormatterTest, SanitizeMetricName) {
   std::string raw = "An.artist.plays-violin@019street";
   std::string expected = "envoy_An_artist_plays_violin_019street";


### PR DESCRIPTION
bring back https://github.com/envoyproxy/envoy-wasm/pull/138/

Signed-off-by: Pengyuan Bian <bianpengyuan@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message:
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
