### PR TITLE
Allow using system gn binary even on linux systems

### DIFF
--- a/bazel/external/wee8.genrule_cmd
+++ b/bazel/external/wee8.genrule_cmd
@@ -90,17 +90,28 @@ if [[ `uname -m` == "aarch64" ]]; then
 fi
 
 # Build wee8.
-if [[ "$$(uname -s)" == "Darwin" ]]; then
+if [[ -f /etc/centos-release ]] && [[ $$(cat /etc/centos-release) =~ "CentOS Linux release 7" ]] && [[ -x "$$(command -v gn)" ]]; then
+  # Using system default gn tools
+  # This is done only for CentOS 7, as it has an old version of GLIBC which is otherwise incompatible
+  gn=$$(command -v gn)
+elif [[ "$$(uname -s)" == "Darwin" ]]; then
   gn=buildtools/mac/gn
-  ninja=third_party/depot_tools/ninja
 elif [[ "$$(uname -s)-$$(uname -m)" == "Linux-x86_64" ]]; then
   gn=buildtools/linux64/gn
+else
+  # Using system default gn tools
+  gn=$$(command -v gn)
+fi
+
+if [[ "$$(uname -s)" == "Darwin" ]]; then
+  ninja=third_party/depot_tools/ninja
+elif [[ "$$(uname -s)-$$(uname -m)" == "Linux-x86_64" ]]; then
   ninja=third_party/depot_tools/ninja
 else
-  # Using system default ninja & gn tools
-  gn=$$(command -v gn)
+  # Using system default ninja tools
   ninja=$$(command -v ninja)
 fi
+
 "$$gn" gen out/wee8 --args="$$WEE8_BUILD_ARGS"
 "$$ninja" -C out/wee8 wee8
 


### PR DESCRIPTION
Commit Message: Allow using system gn binary even on linux systems
Additional Description: Some platforms, such as CentOS 7, do not support the gn binaries that are part of the build system, and need to provide their own. However, since they are linux, they are currently forced into using the bundled binaries. This allows an opt out in this case. I am open to making the condition different, checking for centos 7 was recommended by @jplevyak 
Risk Level: Low
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
