### PR TITLE
Check for failed Wasm in on_resolved_dns().

### DIFF
--- a/source/extensions/bootstrap/wasm/config.cc
+++ b/source/extensions/bootstrap/wasm/config.cc
@@ -27,7 +27,11 @@ void WasmFactory::createWasm(const envoy::extensions::wasm::v3::WasmService& con
   bool singleton = config.singleton();
   auto callback = [&context, singleton, plugin, cb](Common::Wasm::WasmHandleSharedPtr base_wasm) {
     if (!base_wasm) {
-      ENVOY_LOG(error, "Unable to create Wasm service {}", plugin->name_);
+      if (plugin->fail_open_) {
+        ENVOY_LOG(error, "Unable to create Wasm service {}", plugin->name_);
+      } else {
+        ENVOY_LOG(critical, "Unable to create Wasm service {}", plugin->name_);
+      }
       return;
     }
     if (singleton) {

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -166,7 +166,7 @@ void Context::onCloseTCP() {
 void Context::onResolveDns(uint32_t token, Envoy::Network::DnsResolver::ResolutionStatus status,
                            std::list<Envoy::Network::DnsResponse>&& response) {
   proxy_wasm::DeferAfterCallActions actions(this);
-  if (!wasm()->on_resolve_dns_) {
+  if (wasm()->isFailed() || !wasm()->on_resolve_dns_) {
     return;
   }
   if (status != Network::DnsResolver::ResolutionStatus::Success) {


### PR DESCRIPTION
Log a critical error if a Wasm service fails to load
and it is set to fail closed.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

