### PR TITLE
update createStatsSink to use ServerFactoryContext

### DIFF
--- a/include/envoy/server/factory_context.h
+++ b/include/envoy/server/factory_context.h
@@ -140,7 +140,7 @@ public:
   virtual ServerLifecycleNotifier& lifecycleNotifier() PURE;
 
   /**
-   * @return the flush interval of stats sinks.
+   * @return std::chrono::milliseconds the flush interval of stats sinks.
    */
   virtual std::chrono::milliseconds statsFlushInterval() const PURE;
 };

--- a/include/envoy/server/factory_context.h
+++ b/include/envoy/server/factory_context.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <functional>
 #include <memory>
 
@@ -137,6 +138,11 @@ public:
    * @return ServerLifecycleNotifier& the lifecycle notifier for the server.
    */
   virtual ServerLifecycleNotifier& lifecycleNotifier() PURE;
+
+  /**
+   * @return the flush interval of stats sinks.
+   */
+  virtual std::chrono::milliseconds statsFlushInterval() const PURE;
 };
 
 /**

--- a/source/extensions/stat_sinks/dog_statsd/config.cc
+++ b/source/extensions/stat_sinks/dog_statsd/config.cc
@@ -5,6 +5,7 @@
 #include "envoy/config/metrics/v3/stats.pb.h"
 #include "envoy/config/metrics/v3/stats.pb.validate.h"
 #include "envoy/registry/registry.h"
+#include "envoy/server/filter_config.h"
 
 #include "common/network/resolver_impl.h"
 
@@ -16,8 +17,9 @@ namespace Extensions {
 namespace StatSinks {
 namespace DogStatsd {
 
-Stats::SinkPtr DogStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
-                                                     Server::Instance& server) {
+Stats::SinkPtr
+DogStatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
+                                      Server::Configuration::ServerFactoryContext& server) {
   const auto& sink_config =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::DogStatsdSink&>(
           config, server.messageValidationContext().staticValidationVisitor());

--- a/source/extensions/stat_sinks/dog_statsd/config.h
+++ b/source/extensions/stat_sinks/dog_statsd/config.h
@@ -16,7 +16,7 @@ class DogStatsdSinkFactory : Logger::Loggable<Logger::Id::config>,
                              public Server::Configuration::StatsSinkFactory {
 public:
   Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Instance& server) override;
+                                 Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/hystrix/config.cc
+++ b/source/extensions/stat_sinks/hystrix/config.cc
@@ -16,8 +16,9 @@ namespace Extensions {
 namespace StatSinks {
 namespace Hystrix {
 
-Stats::SinkPtr HystrixSinkFactory::createStatsSink(const Protobuf::Message& config,
-                                                   Server::Instance& server) {
+Stats::SinkPtr
+HystrixSinkFactory::createStatsSink(const Protobuf::Message& config,
+                                    Server::Configuration::ServerFactoryContext& server) {
   const auto& hystrix_sink =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::HystrixSink&>(
           config, server.messageValidationContext().staticValidationVisitor());

--- a/source/extensions/stat_sinks/hystrix/config.h
+++ b/source/extensions/stat_sinks/hystrix/config.h
@@ -16,7 +16,7 @@ class HystrixSinkFactory : Logger::Loggable<Logger::Id::config>,
 public:
   // StatsSinkFactory
   Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Instance& server) override;
+                                 Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/hystrix/hystrix.cc
+++ b/source/extensions/stat_sinks/hystrix/hystrix.cc
@@ -271,9 +271,10 @@ const std::string HystrixSink::printRollingWindows() {
   return out_str.str();
 }
 
-HystrixSink::HystrixSink(Server::Instance& server, const uint64_t num_buckets)
+HystrixSink::HystrixSink(Server::Configuration::ServerFactoryContext& server,
+                         const uint64_t num_buckets)
     : server_(server), current_index_(num_buckets > 0 ? num_buckets : DEFAULT_NUM_BUCKETS),
-      window_size_(current_index_ + 1), stat_name_pool_(server.stats().symbolTable()),
+      window_size_(current_index_ + 1), stat_name_pool_(server.scope().symbolTable()),
       cluster_name_(stat_name_pool_.add(Config::TagNames::get().CLUSTER_NAME)),
       cluster_upstream_rq_time_(stat_name_pool_.add("cluster.upstream_rq_time")),
       membership_total_(stat_name_pool_.add("membership_total")),
@@ -348,7 +349,7 @@ void HystrixSink::flush(Stats::MetricSnapshot& snapshot) {
           Stats::Utility::findTag(histogram.get(), cluster_name_);
       // Make sure we found the cluster name tag
       ASSERT(value);
-      std::string value_str = server_.stats().symbolTable().toString(*value);
+      std::string value_str = server_.scope().symbolTable().toString(*value);
       auto it_bool_pair = time_histograms.emplace(std::make_pair(value_str, QuantileLatencyMap()));
       // Make sure histogram with this name was not already added
       ASSERT(it_bool_pair.second);

--- a/source/extensions/stat_sinks/hystrix/hystrix.h
+++ b/source/extensions/stat_sinks/hystrix/hystrix.h
@@ -47,7 +47,7 @@ using ClusterStatsCachePtr = std::unique_ptr<ClusterStatsCache>;
 
 class HystrixSink : public Stats::Sink, public Logger::Loggable<Logger::Id::hystrix> {
 public:
-  HystrixSink(Server::Instance& server, uint64_t num_buckets);
+  HystrixSink(Server::Configuration::ServerFactoryContext& server, uint64_t num_buckets);
   Http::Code handlerHystrixEventStream(absl::string_view, Http::ResponseHeaderMap& response_headers,
                                        Buffer::Instance&, Server::AdminStream& admin_stream);
   void flush(Stats::MetricSnapshot& snapshot) override;
@@ -149,7 +149,7 @@ private:
                             std::stringstream& ss);
 
   std::vector<Http::StreamDecoderFilterCallbacks*> callbacks_list_;
-  Server::Instance& server_;
+  Server::Configuration::ServerFactoryContext& server_;
   uint64_t current_index_;
   const uint64_t window_size_;
   static const uint64_t DEFAULT_NUM_BUCKETS = 10;

--- a/source/extensions/stat_sinks/metrics_service/config.cc
+++ b/source/extensions/stat_sinks/metrics_service/config.cc
@@ -17,8 +17,9 @@ namespace Extensions {
 namespace StatSinks {
 namespace MetricsService {
 
-Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
-                                                          Server::Instance& server) {
+Stats::SinkPtr
+MetricsServiceSinkFactory::createStatsSink(const Protobuf::Message& config,
+                                           Server::Configuration::ServerFactoryContext& server) {
   validateProtoDescriptors();
 
   const auto& sink_config =
@@ -31,7 +32,7 @@ Stats::SinkPtr MetricsServiceSinkFactory::createStatsSink(const Protobuf::Messag
   std::shared_ptr<GrpcMetricsStreamer> grpc_metrics_streamer =
       std::make_shared<GrpcMetricsStreamerImpl>(
           server.clusterManager().grpcAsyncClientManager().factoryForGrpcService(
-              grpc_service, server.stats(), false),
+              grpc_service, server.scope(), false),
           server.localInfo(), transport_api_version);
 
   return std::make_unique<MetricsServiceSink>(

--- a/source/extensions/stat_sinks/metrics_service/config.h
+++ b/source/extensions/stat_sinks/metrics_service/config.h
@@ -17,7 +17,7 @@ class MetricsServiceSinkFactory : Logger::Loggable<Logger::Id::config>,
                                   public Server::Configuration::StatsSinkFactory {
 public:
   Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Instance& server) override;
+                                 Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/extensions/stat_sinks/statsd/config.cc
+++ b/source/extensions/stat_sinks/statsd/config.cc
@@ -16,8 +16,9 @@ namespace Extensions {
 namespace StatSinks {
 namespace Statsd {
 
-Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
-                                                  Server::Instance& server) {
+Stats::SinkPtr
+StatsdSinkFactory::createStatsSink(const Protobuf::Message& config,
+                                   Server::Configuration::ServerFactoryContext& server) {
 
   const auto& statsd_sink =
       MessageUtil::downcastAndValidate<const envoy::config::metrics::v3::StatsdSink&>(
@@ -34,7 +35,7 @@ Stats::SinkPtr StatsdSinkFactory::createStatsSink(const Protobuf::Message& confi
     ENVOY_LOG(debug, "statsd TCP cluster: {}", statsd_sink.tcp_cluster_name());
     return std::make_unique<Common::Statsd::TcpStatsdSink>(
         server.localInfo(), statsd_sink.tcp_cluster_name(), server.threadLocal(),
-        server.clusterManager(), server.stats(), statsd_sink.prefix());
+        server.clusterManager(), server.scope(), statsd_sink.prefix());
   default:
     // Verified by schema.
     NOT_REACHED_GCOVR_EXCL_LINE;

--- a/source/extensions/stat_sinks/statsd/config.h
+++ b/source/extensions/stat_sinks/statsd/config.h
@@ -17,7 +17,7 @@ class StatsdSinkFactory : Logger::Loggable<Logger::Id::config>,
 public:
   // StatsSinkFactory
   Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
-                                 Server::Instance& server) override;
+                                 Server::Configuration::ServerFactoryContext& server) override;
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override;
 

--- a/source/server/configuration_impl.cc
+++ b/source/server/configuration_impl.cc
@@ -134,7 +134,7 @@ void MainImpl::initializeStatsSinks(const envoy::config::bootstrap::v3::Bootstra
     ProtobufTypes::MessagePtr message = Config::Utility::translateToFactoryConfig(
         sink_object, server.messageValidationContext().staticValidationVisitor(), factory);
 
-    stats_sinks_.emplace_back(factory.createStatsSink(*message, server));
+    stats_sinks_.emplace_back(factory.createStatsSink(*message, server.serverFactoryContext()));
   }
 }
 

--- a/source/server/configuration_impl.h
+++ b/source/server/configuration_impl.h
@@ -42,7 +42,8 @@ public:
    * @param config supplies the custom proto configuration for the Stats::Sink
    * @param server supplies the server instance
    */
-  virtual Stats::SinkPtr createStatsSink(const Protobuf::Message& config, Instance& server) PURE;
+  virtual Stats::SinkPtr createStatsSink(const Protobuf::Message& config,
+                                         Server::Configuration::ServerFactoryContext& server) PURE;
 
   std::string category() const override { return "envoy.stats_sinks"; }
 };

--- a/source/server/server.h
+++ b/source/server/server.h
@@ -173,6 +173,9 @@ public:
   Grpc::Context& grpcContext() override { return server_.grpcContext(); }
   Envoy::Server::DrainManager& drainManager() override { return server_.drainManager(); }
   ServerLifecycleNotifier& lifecycleNotifier() override { return server_.lifecycleNotifier(); }
+  std::chrono::milliseconds statsFlushInterval() const override {
+    return server_.statsFlushInterval();
+  }
 
   // Configuration::TransportSocketFactoryContext
   Ssl::ContextManager& sslContextManager() override { return server_.sslContextManager(); }

--- a/test/extensions/stats_sinks/dog_statsd/config_test.cc
+++ b/test/extensions/stats_sinks/dog_statsd/config_test.cc
@@ -48,7 +48,7 @@ TEST_P(DogStatsdConfigLoopbackTest, ValidUdpIp) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   EXPECT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());
@@ -59,7 +59,7 @@ TEST_P(DogStatsdConfigLoopbackTest, ValidUdpIp) {
 
 // Negative test for protoc-gen-validate constraints for dog_statsd.
 TEST(DogStatsdConfigTest, ValidateFail) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   EXPECT_THROW(
       DogStatsdSinkFactory().createStatsSink(envoy::config::metrics::v3::DogStatsdSink(), server),
       ProtoValidationException);
@@ -86,7 +86,7 @@ TEST_P(DogStatsdConfigLoopbackTest, WithCustomPrefix) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   ASSERT_NE(sink, nullptr);
   auto udp_sink = dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get());

--- a/test/extensions/stats_sinks/hystrix/config_test.cc
+++ b/test/extensions/stats_sinks/hystrix/config_test.cc
@@ -35,7 +35,7 @@ TEST(StatsConfigTest, ValidHystrixSink) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Hystrix::HystrixSink*>(sink.get()), nullptr);

--- a/test/extensions/stats_sinks/hystrix/hystrix_test.cc
+++ b/test/extensions/stats_sinks/hystrix/hystrix_test.cc
@@ -241,7 +241,7 @@ public:
   ClusterTestInfo cluster2_{cluster2_name_};
 
   NiceMock<Http::MockStreamDecoderFilterCallbacks> callbacks_;
-  NiceMock<Server::MockInstance> server_;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server_;
   Upstream::ClusterManager::ClusterInfoMap cluster_map_;
 
   std::unique_ptr<HystrixSink> sink_;

--- a/test/extensions/stats_sinks/statsd/config_test.cc
+++ b/test/extensions/stats_sinks/statsd/config_test.cc
@@ -39,7 +39,7 @@ TEST(StatsConfigTest, ValidTcpStatsd) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Common::Statsd::TcpStatsdSink*>(sink.get()), nullptr);
@@ -81,7 +81,7 @@ TEST_P(StatsConfigParameterizedTest, UdpSinkDefaultPrefix) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   ASSERT_NE(sink, nullptr);
 
@@ -113,7 +113,7 @@ TEST_P(StatsConfigParameterizedTest, UdpSinkCustomPrefix) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   ASSERT_NE(sink, nullptr);
 
@@ -136,7 +136,7 @@ TEST(StatsConfigTest, TcpSinkDefaultPrefix) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   ASSERT_NE(sink, nullptr);
 
@@ -161,7 +161,7 @@ TEST(StatsConfigTest, TcpSinkCustomPrefix) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   ASSERT_NE(sink, nullptr);
 
@@ -193,7 +193,7 @@ TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
   ProtobufTypes::MessagePtr message = factory->createEmptyConfigProto();
   TestUtility::jsonConvert(sink_config, *message);
 
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   Stats::SinkPtr sink = factory->createStatsSink(*message, server);
   EXPECT_NE(sink, nullptr);
   EXPECT_NE(dynamic_cast<Common::Statsd::UdpStatsdSink*>(sink.get()), nullptr);
@@ -202,7 +202,7 @@ TEST_P(StatsConfigLoopbackTest, ValidUdpIpStatsd) {
 
 // Negative test for protoc-gen-validate constraints for statsd.
 TEST(StatsdConfigTest, ValidateFail) {
-  NiceMock<Server::MockInstance> server;
+  NiceMock<Server::Configuration::MockServerFactoryContext> server;
   EXPECT_THROW(
       StatsdSinkFactory().createStatsSink(envoy::config::metrics::v3::StatsdSink(), server),
       ProtoValidationException);

--- a/test/mocks/server/factory_context.h
+++ b/test/mocks/server/factory_context.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <chrono>
+
 #include "envoy/server/configuration.h"
 
 #include "extensions/transport_sockets/tls/context_manager_impl.h"

--- a/test/mocks/server/factory_context.h
+++ b/test/mocks/server/factory_context.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <chrono>
-
 #include "envoy/server/configuration.h"
 
 #include "extensions/transport_sockets/tls/context_manager_impl.h"

--- a/test/mocks/server/instance.h
+++ b/test/mocks/server/instance.h
@@ -149,6 +149,7 @@ public:
   MOCK_METHOD(Server::DrainManager&, drainManager, ());
   MOCK_METHOD(Init::Manager&, initManager, ());
   MOCK_METHOD(ServerLifecycleNotifier&, lifecycleNotifier, ());
+  MOCK_METHOD(std::chrono::milliseconds, statsFlushInterval, (), (const));
 
   testing::NiceMock<Upstream::MockClusterManager> cluster_manager_;
   testing::NiceMock<Event::MockDispatcher> dispatcher_;

--- a/test/server/server_test.cc
+++ b/test/server/server_test.cc
@@ -290,8 +290,9 @@ private:
 class CustomStatsSinkFactory : public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message&, Server::Instance& server) override {
-    return std::make_unique<CustomStatsSink>(server.stats());
+  Stats::SinkPtr createStatsSink(const Protobuf::Message&,
+                                 Server::Configuration::ServerFactoryContext& server) override {
+    return std::make_unique<CustomStatsSink>(server.scope());
   }
 
   ProtobufTypes::MessagePtr createEmptyConfigProto() override {
@@ -1180,7 +1181,7 @@ TEST_P(StaticValidationTest, ClusterUnknownField) {
 // Custom StatsSink that registers both a Cluster update callback and Server lifecycle callback.
 class CallbacksStatsSink : public Stats::Sink, public Upstream::ClusterUpdateCallbacks {
 public:
-  CallbacksStatsSink(Server::Instance& server)
+  CallbacksStatsSink(Server::Configuration::ServerFactoryContext& server)
       : cluster_removal_cb_handle_(
             server.clusterManager().addThreadLocalClusterUpdateCallbacks(*this)),
         lifecycle_cb_handle_(server.lifecycleNotifier().registerCallback(
@@ -1203,7 +1204,8 @@ private:
 class CallbacksStatsSinkFactory : public Server::Configuration::StatsSinkFactory {
 public:
   // StatsSinkFactory
-  Stats::SinkPtr createStatsSink(const Protobuf::Message&, Server::Instance& server) override {
+  Stats::SinkPtr createStatsSink(const Protobuf::Message&,
+                                 Server::Configuration::ServerFactoryContext& server) override {
     return std::make_unique<CallbacksStatsSink>(server);
   }
 


### PR DESCRIPTION
Signed-off-by: Aakash Shukla <aakashshukla@google.com>

Commit Message: updated creatStatSink function to take in Server::Configuration::ServerFactoryContext as a parameter instead of Server::Instance.
Additional Description: This change is necessary for wasm-stat-sink endpoint (https://github.com/envoyproxy/envoy-wasm/pull/566), since the createWasm call needed to instantiate the wasm endpoint requires FactoryContext object methods (such as but not limited to ClusterManager() and scope()).
Risk Level: Low
