### PR TITLE
Implement proxy_get_log_level

### DIFF
--- a/bazel/repository_locations.bzl
+++ b/bazel/repository_locations.bzl
@@ -513,9 +513,9 @@ DEPENDENCY_REPOSITORIES = dict(
         cpe = "N/A",
     ),
     proxy_wasm_cpp_host = dict(
-        sha256 = "8932d72e321c7c527794d12e1864ddab95276b77bebb0b2c2f6fbc49b2b4b39a",
-        strip_prefix = "proxy-wasm-cpp-host-5afe9bdc9d3dc833522332b5c0b87e1339fd2da2",
-        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/5afe9bdc9d3dc833522332b5c0b87e1339fd2da2.tar.gz"],
+        sha256 = "1cc5334ce433507371d7ccb58c87e07ca6bd1582a75a5dafe02a89a54106db98",
+        strip_prefix = "proxy-wasm-cpp-host-4598dc3d0d3b731be1dcccb400732c72bebb1380",
+        urls = ["https://github.com/proxy-wasm/proxy-wasm-cpp-host/archive/4598dc3d0d3b731be1dcccb400732c72bebb1380.tar.gz"],
         use_category = ["dataplane"],
         cpe = "N/A",
     ),

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1110,6 +1110,12 @@ WasmResult Context::log(uint32_t level, absl::string_view message) {
   NOT_REACHED_GCOVR_EXCL_LINE;
 }
 
+uint32_t Context::getLogLevel() {
+  // Like the "log" call above, assume that spdlog level as an int
+  // matches the enum in the SDK
+  return static_cast<uint32_t>(ENVOY_LOGGER().level());
+}
+
 //
 // Calls into the Wasm code.
 //

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -163,6 +163,7 @@ public:
            const Http::ResponseHeaderMap* response_headers,
            const Http::ResponseTrailerMap* response_trailers,
            const StreamInfo::StreamInfo& stream_info) override;
+  uint32_t getLogLevel() override;
 
   // Network::ConnectionCallbacks
   void onEvent(Network::ConnectionEvent event) override;

--- a/test/extensions/common/wasm/test_data/test_cpp.cc
+++ b/test/extensions/common/wasm/test_data/test_cpp.cc
@@ -56,6 +56,10 @@ WASM_EXPORT(uint32_t, proxy_on_vm_start, (uint32_t context_id, uint32_t configur
     proxy_log(LogLevel::warn, warn_message.c_str(), warn_message.size());
     std::string error_message = "test error logging";
     proxy_log(LogLevel::error, error_message.c_str(), error_message.size());
+    LogLevel log_level;
+    CHECK_RESULT(proxy_get_log_level(&log_level));
+    std::string level_message = "log level is " + std::to_string(static_cast<uint32_t>(log_level));
+    proxy_log(LogLevel::info, level_message.c_str(), level_message.size());
   } else if (configuration == "segv") {
     std::string message = "before badptr";
     proxy_log(LogLevel::error, message.c_str(), message.size());

--- a/test/extensions/common/wasm/test_data/test_cpp.cc
+++ b/test/extensions/common/wasm/test_data/test_cpp.cc
@@ -37,7 +37,7 @@ static float gInfinity = INFINITY;
     abort();                                                                                       \
   } while (0)
 
-WASM_EXPORT(void, proxy_abi_version_0_2_0, (void)) {}
+WASM_EXPORT(void, proxy_abi_version_0_2_1, (void)) {}
 
 WASM_EXPORT(void, proxy_on_context_create, (uint32_t, uint32_t)) {}
 

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -61,7 +61,10 @@ public:
 
 class WasmCommonTest : public testing::TestWithParam<std::string> {
 public:
-  void SetUp() { clearCodeCacheForTesting(); }
+  void SetUp() {
+    Logger::Registry::getLog(Logger::Id::wasm).set_level(spdlog::level::debug);
+    clearCodeCacheForTesting();
+  }
 };
 
 INSTANTIATE_TEST_SUITE_P(Runtimes, WasmCommonTest,
@@ -115,7 +118,7 @@ TEST_P(WasmCommonTest, Logging) {
         EXPECT_CALL(*root_context, log_(spdlog::level::debug, Eq("test debug logging")));
         EXPECT_CALL(*root_context, log_(spdlog::level::warn, Eq("test warn logging")));
         EXPECT_CALL(*root_context, log_(spdlog::level::err, Eq("test error logging")));
-        EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("log level is 4")));
+        EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("log level is 1")));
         EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_done logging")));
         EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_delete logging")));
         return root_context;

--- a/test/extensions/common/wasm/wasm_test.cc
+++ b/test/extensions/common/wasm/wasm_test.cc
@@ -115,6 +115,7 @@ TEST_P(WasmCommonTest, Logging) {
         EXPECT_CALL(*root_context, log_(spdlog::level::debug, Eq("test debug logging")));
         EXPECT_CALL(*root_context, log_(spdlog::level::warn, Eq("test warn logging")));
         EXPECT_CALL(*root_context, log_(spdlog::level::err, Eq("test error logging")));
+        EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("log level is 4")));
         EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_done logging")));
         EXPECT_CALL(*root_context, log_(spdlog::level::info, Eq("on_delete logging")));
         return root_context;


### PR DESCRIPTION
This hooks up the proxy runtime to the support that's already been added to the host and SDK libraries.

Signed-off-by: Gregory Brail <gregbrail@google.com>
