### PR TITLE
ci: fix spell format

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,12 +87,7 @@ jobs:
      steps:
        - run: rm -rf /home/circleci/project/.git # CircleCI git caching is likely broken
        - checkout
-       - run: pip install -r tools/code_format/requirements.txt
-       - run: ci/do_circle_ci.sh check_format
-       - run: ci/do_circle_ci.sh check_repositories
-       - run: ci/do_circle_ci.sh check_spelling
-       # TODO(PiotrSikora): re-enable once fixed.
-       # - run: ci/do_circle_ci.sh check_spelling_pedantic
+       - run: ci/check_and_fix_format.sh
 
    macos:
      macos:

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -217,7 +217,7 @@ void Context::onStatsUpdate(Envoy::Stats::MetricSnapshot& snapshot) {
   //    name
   //    8 byte alignment padding
   //    8 bytes of absolute value
-  //    8 bytes of delta  (if appropropriate, e.g. for counters)
+  //    8 bytes of delta  (if appropriate, e.g. for counters)
   //  uint32 size of block of this type
 
   const uint64_t padding = 0;
@@ -554,7 +554,7 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
     start = end + 1;
 
     if (first) {
-      // top-level ident
+      // top-level indent
       first = false;
       auto top_value = findValue(part, &arena, start >= path.size());
       if (!top_value.has_value()) {

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -554,7 +554,7 @@ WasmResult Context::getProperty(absl::string_view path, std::string* result) {
     start = end + 1;
 
     if (first) {
-      // top-level indent
+      // top-level identifier
       first = false;
       auto top_value = findValue(part, &arena, start >= path.size());
       if (!top_value.has_value()) {

--- a/source/extensions/common/wasm/context.h
+++ b/source/extensions/common/wasm/context.h
@@ -153,7 +153,7 @@ public:
   const Network::Connection* getConnection() const;
 
   //
-  // VM level downcalls into the Wasm code on Context(id == 0).
+  // VM level down-calls into the Wasm code on Context(id == 0).
   //
   virtual bool validateConfiguration(absl::string_view configuration,
                                      const std::shared_ptr<PluginBase>& plugin); // deprecated

--- a/source/extensions/common/wasm/wasm_extension.h
+++ b/source/extensions/common/wasm/wasm_extension.h
@@ -44,7 +44,7 @@ struct CreateWasmStats {
   CREATE_WASM_STATS(GENERATE_COUNTER_STRUCT, GENERATE_GAUGE_STRUCT)
 };
 
-// Extension point for Wasm clients in enbedded Envoy.
+// Extension point for Wasm clients in embedded Envoy.
 class WasmExtension : Logger::Loggable<Logger::Id::wasm> {
 public:
   WasmExtension() = default;

--- a/test/extensions/bootstrap/wasm/wasm_speed_test.cc
+++ b/test/extensions/bootstrap/wasm/wasm_speed_test.cc
@@ -2,9 +2,7 @@
  * Simple WASM speed test.
  *
  * Run with:
- * TEST_SRCDIR=`pwd` TEST_WORKSPACE=bazel-$(basename `pwd`) bazel run --define wasm=enabled
- * --config=libc++ -c opt //test/extensions/bootstrap/wasm:wasm_speed_test
- * Note: "--linkopt -fuse-ld=ldd" may be required as well depending on the build environment.
+ * `bazel run --config=libc++ -c opt //test/extensions/bootstrap/wasm:wasm_speed_test`
  */
 #include <stdio.h>
 

--- a/test/extensions/common/wasm/test_data/test_cpp.cc
+++ b/test/extensions/common/wasm/test_data/test_cpp.cc
@@ -166,7 +166,7 @@ WASM_EXPORT(uint32_t, proxy_on_vm_start, (uint32_t context_id, uint32_t configur
     if (pathenv != nullptr) {
       FAIL_NOW("PATH environment variable should not be available");
     }
-    // Exercise the WASI "fd_fdstat_get" a little bit
+    // Exercise the WASI `fd_fdstat_get` a little bit
     int tty = isatty(1);
     if (errno != ENOTTY || tty != 0) {
       FAIL_NOW("stdout is not a tty");

--- a/test/extensions/filters/http/wasm/wasm_filter_test.cc
+++ b/test/extensions/filters/http/wasm/wasm_filter_test.cc
@@ -142,7 +142,7 @@ TEST_P(WasmHttpFilterTest, HeadersOnlyRequestHeadersAndBody) {
 
 TEST_P(WasmHttpFilterTest, HeadersStopAndContinue) {
   if (std::get<1>(GetParam()) == "rust") {
-    // TODO(PiotrSikora): This handoff is not currently possible in the Rust SDK.
+    // TODO(PiotrSikora): This hand off is not currently possible in the Rust SDK.
     return;
   }
   setupTest("", "headers");
@@ -163,7 +163,7 @@ TEST_P(WasmHttpFilterTest, HeadersStopAndContinue) {
 
 TEST_P(WasmHttpFilterTest, HeadersStopAndEndStream) {
   if (std::get<1>(GetParam()) == "rust") {
-    // TODO(PiotrSikora): This handoff is not currently possible in the Rust SDK.
+    // TODO(PiotrSikora): This hand off is not currently possible in the Rust SDK.
     return;
   }
   setupTest("", "headers");
@@ -185,7 +185,7 @@ TEST_P(WasmHttpFilterTest, HeadersStopAndEndStream) {
 
 TEST_P(WasmHttpFilterTest, HeadersStopAndBuffer) {
   if (std::get<1>(GetParam()) == "rust") {
-    // TODO(PiotrSikora): This handoff is not currently possible in the Rust SDK.
+    // TODO(PiotrSikora): This hand off is not currently possible in the Rust SDK.
     return;
   }
   setupTest("", "headers");
@@ -207,7 +207,7 @@ TEST_P(WasmHttpFilterTest, HeadersStopAndBuffer) {
 
 TEST_P(WasmHttpFilterTest, HeadersStopAndWatermark) {
   if (std::get<1>(GetParam()) == "rust") {
-    // TODO(PiotrSikora): This handoff is not currently possible in the Rust SDK.
+    // TODO(PiotrSikora): This hand off is not currently possible in the Rust SDK.
     return;
   }
   setupTest("", "headers");
@@ -523,7 +523,7 @@ TEST_P(WasmHttpFilterTest, AsyncCallAfterDestroyed) {
 
 TEST_P(WasmHttpFilterTest, GrpcCall) {
   if (std::get<1>(GetParam()) == "rust") {
-    // TODO(PiotrSikora): gRPC callouts not yet supported in the Rust SDK.
+    // TODO(PiotrSikora): gRPC call outs not yet supported in the Rust SDK.
     return;
   }
   setupTest("", "grpc_call");
@@ -577,7 +577,7 @@ TEST_P(WasmHttpFilterTest, GrpcCall) {
 
 TEST_P(WasmHttpFilterTest, GrpcCallAfterDestroyed) {
   if (std::get<1>(GetParam()) == "rust") {
-    // TODO(PiotrSikora): gRPC callouts not yet supported in the Rust SDK.
+    // TODO(PiotrSikora): gRPC call outs not yet supported in the Rust SDK.
     return;
   }
   setupTest("", "grpc_call");

--- a/tools/spelling/spelling_dictionary.txt
+++ b/tools/spelling/spelling_dictionary.txt
@@ -15,6 +15,7 @@ API
 ARN
 ASAN
 ASCII
+ASM
 ASSERTs
 AST
 AWS
@@ -26,6 +27,10 @@ CAS
 CB
 CDS
 CEL
+EMSDK
+FBS
+SEGV
+WASI
 ceil
 CHACHA
 CHLO
@@ -604,6 +609,8 @@ filesystem
 firefox
 fixdate
 fixup
+flatbuffer
+flatc
 fmt
 fmtlib
 fn
@@ -740,6 +747,7 @@ lua
 lyft
 maglev
 malloc
+marshaller
 matchable
 matcher
 matchers
@@ -784,6 +792,7 @@ mysql
 namelen
 nameserver
 namespace
+namespaced
 namespaces
 namespacing
 nan
@@ -878,6 +887,7 @@ preflight
 preorder
 prepend
 prepended
+prepends
 prev
 probabilistically
 proc
@@ -1027,6 +1037,7 @@ stateful
 statsd
 stderr
 stdev
+stdin
 stdout
 stmt
 str


### PR DESCRIPTION
This should let the branch pass all upstream format check.

Signed-off-by: Lizan Zhou <lizan@tetrate.io>

