### PR TITLE
Create the VM context as a Wasm::Context for consistency.

### DIFF
--- a/source/extensions/common/wasm/wasm.cc
+++ b/source/extensions/common/wasm/wasm.cc
@@ -240,6 +240,8 @@ ContextBase* Wasm::createRootContext(const std::shared_ptr<PluginBase>& plugin) 
   return new Context(this, std::static_pointer_cast<Plugin>(plugin));
 }
 
+ContextBase* Wasm::createVmContext() { return new Context(this); }
+
 void Wasm::log(absl::string_view root_id, const Http::RequestHeaderMap* request_headers,
                const Http::ResponseHeaderMap* response_headers,
                const Http::ResponseTrailerMap* response_trailers,

--- a/source/extensions/common/wasm/wasm.h
+++ b/source/extensions/common/wasm/wasm.h
@@ -67,6 +67,7 @@ public:
   proxy_wasm::CallOnThreadFunction callOnThreadFunction() override;
   ContextBase* createContext(const std::shared_ptr<PluginBase>& plugin) override;
   ContextBase* createRootContext(const std::shared_ptr<PluginBase>& plugin) override;
+  ContextBase* createVmContext() override;
   void registerCallbacks() override;
   void getFunctions() override;
 


### PR DESCRIPTION
Signed-off-by: John Plevyak <jplevyak@gmail.com>

