### PR TITLE
Fix wasm onLog

### DIFF
--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1404,7 +1404,7 @@ void Context::log(const Http::RequestHeaderMap* request_headers,
                   const Http::ResponseTrailerMap* response_trailers,
                   const StreamInfo::StreamInfo& stream_info) {
   if (!http_request_started_) {
-    return;
+    onCreate();
   }
   access_log_request_headers_ = request_headers;
   // ? request_trailers  ?

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1403,9 +1403,14 @@ void Context::log(const Http::RequestHeaderMap* request_headers,
                   const Http::ResponseHeaderMap* response_headers,
                   const Http::ResponseTrailerMap* response_trailers,
                   const StreamInfo::StreamInfo& stream_info) {
-  if (!http_request_started_) {
+  if (!in_vm_context_created_) {
+    // If the request is invalid then onRequestHeaders() will not be called and neither will
+    // onCreate() in cases like sendLocalReply who short-circuits envoy
+    // lifecycle. This is because Envoy does not have a well defined lifetime for the combined HTTP
+    // + AccessLog filter. Thus, to log these scenarios, we call onCreate() in log function below.
     onCreate();
   }
+
   access_log_request_headers_ = request_headers;
   // ? request_trailers  ?
   access_log_response_headers_ = response_headers;


### PR DESCRIPTION
Signed-off-by: gargnupur <gargnupur@google.com>

For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Don't return in log, if request is not started. We miss cases like localReply in that scenario
Additional Description:
Risk Level:
Testing:
Docs Changes:
Release Notes:
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
