### PR TITLE
Add plugin_configuration param to WasmTestBase.setupBase

### DIFF
--- a/test/test_common/wasm_base.h
+++ b/test/test_common/wasm_base.h
@@ -45,7 +45,8 @@ public:
   void SetUp() override { clearCodeCacheForTesting(); }
 
   void setupBase(const std::string& runtime, const std::string& code, CreateContextFn create_root,
-                 std::string root_id = "", std::string vm_configuration = "") {
+                 std::string root_id = "", std::string vm_configuration = "",
+                 std::string plugin_configuration = "") {
     envoy::extensions::wasm::v3::VmConfig vm_config;
     vm_config.set_vm_id("vm_id");
     vm_config.set_runtime(absl::StrCat("envoy.wasm.runtime.", runtime));
@@ -57,7 +58,6 @@ public:
     scope_ = Stats::ScopeSharedPtr(stats_store_.createScope("wasm."));
     auto name = "plugin_name";
     auto vm_id = "";
-    auto plugin_configuration = "";
     plugin_ = std::make_shared<Extensions::Common::Wasm::Plugin>(
         name, root_id, vm_id, runtime, plugin_configuration, false,
         envoy::config::core::v3::TrafficDirection::INBOUND, local_info_, &listener_metadata_);


### PR DESCRIPTION
<!--
!!!ATTENTION!!!

If you are fixing *any* crash or *any* potential security issue, *do not*
open a pull request in this repo. Please report the issue via emailing
envoy-security@googlegroups.com where the issue will be triaged appropriately.
Thank you in advance for helping to keep Envoy secure.

!!!ATTENTION!!!

-->
For an explanation of how to fill out the fields, please see the relevant section
in [PULL_REQUESTS.md](https://github.com/envoyproxy/envoy/blob/master/PULL_REQUESTS.md)

Commit Message: Add plugin_configuration param to WasmTestBase.setupBase
Additional Description: This is a test only change, allows unit tests to pass plugin configuration to the tested plugin
Risk Level: Low
Testing: bazel build //test/test_common:wasm_lib 
Docs Changes: None
Release Notes: None
[Optional Runtime guard:]
[Optional Fixes #Issue]
[Optional Deprecated:]
