### PR TITLE
It seems that the core Http Filter lifecycle has changed in Envoy.

### DIFF
--- a/examples/wasm/envoy.yaml
+++ b/examples/wasm/envoy.yaml
@@ -18,7 +18,7 @@ static_resources:
   - address:
       socket_address:
         address: 0.0.0.0
-        port_value: 80
+        port_value: 8000
     filter_chains:
     - filters:
       - name: envoy.filters.network.http_connection_manager

--- a/source/extensions/common/wasm/context.cc
+++ b/source/extensions/common/wasm/context.cc
@@ -1449,10 +1449,6 @@ void Context::log(const Http::RequestHeaderMap* request_headers,
   access_log_response_headers_ = nullptr;
   access_log_response_trailers_ = nullptr;
   access_log_stream_info_ = nullptr;
-
-  if (!isRootContext()) {
-    onDelete();
-  }
 }
 
 void Context::onDestroy() {
@@ -1461,6 +1457,7 @@ void Context::onDestroy() {
   }
   destroyed_ = true;
   onDone();
+  onDelete();
 }
 
 WasmResult Context::continueStream(WasmStreamType stream_type) {


### PR DESCRIPTION
onDestroy is now called *after* log().  Move onDelete into onDestroy()
to deal with this.

Signed-off-by: John Plevyak <jplevyak@gmail.com>

